### PR TITLE
Add missing assert

### DIFF
--- a/src/device_buffer.h
+++ b/src/device_buffer.h
@@ -21,6 +21,8 @@ limitations under the License.
 
 #include <cuda_runtime.h>
 
+#include <cassert>
+
 namespace cuba
 {
 template <typename T>


### PR DESCRIPTION
Adds the missing assert header to `device_buffer.h` 