### PR TITLE
Allow shared builds of library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,7 @@ project(CudaBundleAdjustment)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-set(ENABLE_SAMPLES FALSE)
-set(WITH_G2O  FALSE)
-option(USE_FLOAT32    "Use 32bit float in internal floating-point operations (default is 64bit float)" OFF)
+option(USE_FLOAT32 "Use 32bit float in internal floating-point operations (default is 64bit float)" OFF)
 
 # Eigen
 find_package(Eigen3 REQUIRED)

--- a/conanfile.py
+++ b/conanfile.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import os
 
 
-class CubaConan(ConanFile):
+class CugoConan(ConanFile):
     name = "cuba"
     license = "Apache License 2.0"
     author = "fixstars"
@@ -22,7 +22,7 @@ class CubaConan(ConanFile):
         "use_float32": [True, False]
     }
     default_options = {
-        "shared": False,
+        "shared": True,
         "fPIC": True,
         "with_samples": True,
         "with_g2o": False,
@@ -51,6 +51,7 @@ class CubaConan(ConanFile):
         tc.variables["ENABLE_SAMPLES"] = self.options.with_samples
         tc.variables["WITH_G2O"] = self.options.with_g2o
         tc.variables["USE_FLOAT32"] = self.options.use_float32
+        tc.variables["BUILD_CUGO_SHARED"] = bool(self.options.shared)
         
         tc.generate()
 
@@ -72,6 +73,6 @@ class CubaConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)
-        self.cpp_info.set_property("cmake_file_name", "cuba")
-        self.cpp_info.set_property("cmake_target_name", "cuba::cuba")
+        self.cpp_info.set_property("cmake_file_name", "cugo")
+        self.cpp_info.set_property("cmake_target_name", "cugo::cugo")
 

--- a/include/cuda_bundle_adjustment.h
+++ b/include/cuda_bundle_adjustment.h
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include "device_buffer.h"
 #include "device_matrix.h"
+#include "macro.h"
 
 #include <array>
 #include <cmath>
@@ -51,13 +52,14 @@ using VertexSetVec = std::vector<BaseVertexSet*>;
 
 /** @brief information about optimization.
  */
-struct BatchInfo
+struct CUGO_API BatchInfo
 {
     int iteration; //!< iteration number
     double chi2; //!< total chi2 (objective function value)
 };
 
-class BatchStatistics
+
+class CUGO_API BatchStatistics
 {
 public:
     BatchInfo& getStartStats()
@@ -106,7 +108,7 @@ It optimizes camera poses and landmarks (3D points) represented by a graph.
 added in the graph.
 
 */
-class CudaBundleAdjustment
+class CUGO_API CudaBundleAdjustment
 {
 public:
     using Ptr = UniquePtr<CudaBundleAdjustmentImpl>;
@@ -150,7 +152,7 @@ public:
 
 /** @brief Implementation of CudaBundleAdjustment.
  */
-class CudaBundleAdjustmentImpl : public CudaBundleAdjustment
+class CUGO_API CudaBundleAdjustmentImpl : public CudaBundleAdjustment
 {
 public:
     /**

--- a/include/cuda_bundle_adjustment_types.h
+++ b/include/cuda_bundle_adjustment_types.h
@@ -29,7 +29,7 @@ limitations under the License.
 
 namespace cuba
 {
-class StereoEdgeSet : public EdgeSet<3, maths::Vec3d, Vec3d, PoseVertex, LandmarkVertex>
+class CUGO_API StereoEdgeSet : public EdgeSet<3, maths::Vec3d, Vec3d, PoseVertex, LandmarkVertex>
 {
 public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -105,8 +105,7 @@ public:
 private:
 };
 
-
-class MonoEdgeSet : public EdgeSet<2, maths::Vec2d, Vec2d, PoseVertex, LandmarkVertex>
+class CUGO_API MonoEdgeSet : public EdgeSet<2, maths::Vec2d, Vec2d, PoseVertex, LandmarkVertex>
 {
 public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -184,7 +183,7 @@ private:
 
 /** @brief Edge with 2-dimensional measurement (monocular observation).
  */
-class MonoEdge : public Edge<2, maths::Vec2d, PoseVertex, LandmarkVertex>
+class CUGO_API MonoEdge : public Edge<2, maths::Vec2d, PoseVertex, LandmarkVertex>
 {
 public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -194,7 +193,7 @@ public:
 
 /** @brief Edge with 3-dimensional measurement (stereo observation).
  */
-class StereoEdge : public Edge<3, maths::Vec3d, PoseVertex, LandmarkVertex>
+class CUGO_API StereoEdge : public Edge<3, maths::Vec3d, PoseVertex, LandmarkVertex>
 {
 public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/include/icp_types.h
+++ b/include/icp_types.h
@@ -16,7 +16,7 @@
 
 namespace cuba
 {
-class LineEdgeSet
+class CUGO_API LineEdgeSet 
     : public EdgeSet<1, PointToLineMatch<double>, PointToLineMatch<double>, PoseVertex>
 {
 public:
@@ -60,7 +60,8 @@ public:
 private:
 };
 
-class PlaneEdgeSet
+
+class CUGO_API PlaneEdgeSet
     : public EdgeSet<1, PointToPlaneMatch<double>, PointToPlaneMatch<double>, PoseVertex>
 {
 public:
@@ -104,7 +105,8 @@ public:
 private:
 };
 
-class PlaneEdge : public Edge<1, cuba::PointToPlaneMatch<double>, cuba::PoseVertex>
+
+class CUGO_API PlaneEdge : public Edge<1, cuba::PointToPlaneMatch<double>, cuba::PoseVertex>
 {
 public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -113,7 +115,7 @@ public:
 };
 
 
-class LineEdge : public Edge<1, cuba::PointToLineMatch<double>, cuba::PoseVertex>
+class CUGO_API LineEdge : public Edge<1, cuba::PointToLineMatch<double>, cuba::PoseVertex>
 {
 public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/samples/sample_ba_from_file/CMakeLists.txt
+++ b/samples/sample_ba_from_file/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(sample_ba_from_file LANGUAGES CXX CUDA)
+project(sample_ba_from_file LANGUAGES CXX)
 
 set(SAMPLE_UTILITY_DIR ../utility)
 
@@ -9,26 +9,29 @@ if (CMAKE_COMPILER_IS_GNUCXX)
 endif()
 
 if (WIN32)
-	add_compile_options(/wd4819)
 	add_definitions(-D_SILENCE_CXX17_NEGATORS_DEPRECATION_WARNING)
 endif()
 
 # CUDA
-find_package(CUDA REQUIRED)
-include_directories(${CUDA_INCLUDE_DIRS})
-
-if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-  set(CMAKE_CUDA_ARCHITECTURES 61)
-endif()
-
-CUDA_SELECT_NVCC_ARCH_FLAGS(ARCH_FLAGS "Auto")
-
-include_directories(${CMAKE_SOURCE_DIR}/include)
-include_directories(${SAMPLE_UTILITY_DIR})
+find_package(CUDAToolkit REQUIRED)
 
 file(GLOB srcs ./*.cpp ./*.h* ${SAMPLE_UTILITY_DIR}/*.cpp ${SAMPLE_UTILITY_DIR}/*.h*)
+
 add_executable(sample_ba_from_file ${srcs})
+
+target_include_directories(
+	sample_ba_from_file 
+	PUBLIC 
+	"${CMAKE_SOURCE_DIR}/include" 
+	${SAMPLE_UTILITY_DIR}
+	${CUDAToolkit_INCLUDE_DIRS}
+)
 target_compile_features(sample_ba_from_file PUBLIC cxx_std_11)
-target_link_libraries(sample_ba_from_file opencv::opencv cuda_bundle_adjustment Eigen3::Eigen3)
+target_link_libraries(
+	sample_ba_from_file 
+	opencv::opencv 
+	cugo 
+	Eigen3::Eigen3
+)
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,27 +1,29 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(cuda_bundle_adjustment LANGUAGES CXX CUDA)
+project(cugo LANGUAGES CXX CUDA)
 
-set(CUBA_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/include)
-include_directories(${CUBA_INCLUDE_DIR})
+set(CUGO_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/include)
+include_directories(${CUGO_INCLUDE_DIR})
 
-if (DEBUG_CUDA)
+if (DEBUG_CUGO)
 	set(CMAKE_CUDA_FLAGS ${CMAKE_CUDA_FLAGS} "-g -G -lineinfo")
 else()
 	set(CMAKE_CUDA_FLAGS ${CMAKE_CUDA_FLAGS} "-lineinfo")
 endif()
 
-# Flags for each platform
 if (CMAKE_COMPILER_IS_GNUCXX)
 	set(CMAKE_CXX_FLAGS "-O3 -Wall")
 endif()
 
-find_package(CUDA REQUIRED)
-include_directories(${CUDA_INCLUDE_DIRS})
+find_package(CUDAToolkit REQUIRED)
+if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+  set(CMAKE_CUDA_ARCHITECTURES 61 75)
+endif()
+message(STATUS "CUDA Found: ${CUDAToolkit_FOUND}")
+message(STATUS "CUDA Toolkit version: ${CUDAToolkit_VERSION}")
 
 if (WIN32)
 	set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -dc -Xcompiler \"/wd 4819\" -Xcompiler \"/wd 4244\"")
-	add_compile_options(/wd4819)
 	add_definitions(-D_SILENCE_CXX17_NEGATORS_DEPRECATION_WARNING)
 endif()
 
@@ -29,28 +31,64 @@ if (USE_FLOAT32)
 	add_definitions(-DUSE_FLOAT32)
 endif()
 
-if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-  set(CMAKE_CUDA_ARCHITECTURES 75)
+file(GLOB_RECURSE cpp_srcs ./*.cpp ./*.h ./*.cu ${CUGO_INCLUDE_DIR}/*.h)
+
+if (BUILD_CUGO_SHARED) 
+	add_library(cugo SHARED ${srcs})
+	set(CUDA_LIBS 
+		CUDA::cusparse 
+		CUDA::cusolver
+		CUDA::cublas
+		CUDA::cublasLt 
+		CUDA::cudart
+	)
+else()
+	add_library(cugo STATIC ${cpp_srcs})
+	set(CUDA_LIBS 
+		CUDA::cusparse_static 
+		CUDA::cusolver_static 
+		CUDA::cublas_static 
+		CUDA::cublasLt_static 
+		CUDA::cudart_static
+		${CUDAToolkit_LIBRARY_DIR}/libmetis_static.a
+	)
 endif()
 
-message(STATUS "CUDA_ARCH: \"${CMAKE_CUDA_ARCHITECTURES}\"")
-
-file(GLOB_RECURSE srcs ./*.cpp ./*.cu ./*.h ${CUBA_INCLUDE_DIR}/*.h)
-add_library(cuda_bundle_adjustment STATIC ${srcs})
-
-target_compile_features(cuda_bundle_adjustment PUBLIC cxx_std_11)
-target_link_libraries(cuda_bundle_adjustment PUBLIC ${CUDA_cusparse_LIBRARY} ${CUDA_cusolver_LIBRARY} Eigen3::Eigen3)
-target_include_directories(cuda_bundle_adjustment PUBLIC "${CMAKE_SOURCE_DIR}/src")
-
-install(
-	TARGETS cuda_bundle_adjustment
-	ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
-	LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
-	RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
+target_compile_features(
+	cugo 
+	PUBLIC 
+	cxx_std_11
 )
 
+target_link_libraries(
+	cugo
+	PUBLIC 
+	${CUDA_LIBS}
+	Eigen3::Eigen3
+)
+target_include_directories(cugo PUBLIC "${CMAKE_SOURCE_DIR}/src")
+set_property(TARGET cugo PROPERTY CUDA_RESOLVE_DEVICE_SYMBOLS OFF)
+set_property(TARGET cugo PROPERTY CUDA_SEPARABLE_COMPILATION OFF)
+set_target_properties(cugo PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+
+if (BUILD_CUGO_SHARED)
+	target_compile_options(cugo PRIVATE "-fvisibility=hidden")
+endif()
+
 install(
-	DIRECTORY ${CUBA_INCLUDE_DIR}
-	DESTINATION ${CMAKE_INSTALL_PREFIX}
+	TARGETS cugo 
+	LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+	ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+	RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+)
+install(
+	DIRECTORY ${CUGO_INCLUDE_DIR}/
+	DESTINATION "include/cugo"
+	FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
+)
+install(
+	DIRECTORY ${CMAKE_SOURCE_DIR}/src/
+	DESTINATION "include/cugo"
 	FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
 )

--- a/src/cuda/cuda_block_solver.h
+++ b/src/cuda/cuda_block_solver.h
@@ -102,7 +102,7 @@ void updateLandmarks(const GpuLx1BlockVec& xl, GpuVec3d& Xws);
 void computeScale(const GpuVec1d& x, const GpuVec1d& b, Scalar* scale, Scalar lambda);
 
 template <int M>
-void constructQuadraticForm_(
+void CUGO_API constructQuadraticForm_(
     const GpuVec3d& Xcs,
     const GpuVecSe3d& se3,
     GpuVecxd<M>& errors,
@@ -117,7 +117,7 @@ void constructQuadraticForm_(
     GpuHplBlockMat& Hpl);
 
 template <int M>
-Scalar computeActiveErrors_(
+Scalar CUGO_API computeActiveErrors_(
     const GpuVecSe3d& poseEstimate,
     const GpuVec3d& landmarkEstimate,
     const GpuVecxd<M>& measurements,
@@ -127,7 +127,7 @@ Scalar computeActiveErrors_(
     GpuVec3d& Xcs,
     Scalar* chi);
 
-Scalar computeActiveErrors_Line(
+Scalar CUGO_API computeActiveErrors_Line(
     const GpuVecSe3d& poseEstimate,
     const GpuVec<PointToLineMatch<double>>& measurements,
     const GpuVec1d& omegas,
@@ -136,7 +136,7 @@ Scalar computeActiveErrors_Line(
     GpuVec3d& Xcs,
     Scalar* chi);
 
-Scalar computeActiveErrors_Plane(
+Scalar CUGO_API computeActiveErrors_Plane(
     const GpuVecSe3d& poseEstimate,
     const GpuVec<PointToPlaneMatch<double>>& measurements,
     const GpuVec1d& omegas,
@@ -145,7 +145,7 @@ Scalar computeActiveErrors_Plane(
     GpuVec3d& Xcs,
     Scalar* chi);
 
-Scalar computeActiveErrors_PriorPose(
+Scalar CUGO_API computeActiveErrors_PriorPose(
     const GpuVecSe3d& poseEstimate,
     const GpuVecSe3d& measurements,
     const GpuVec1d& omegas,
@@ -154,7 +154,7 @@ Scalar computeActiveErrors_PriorPose(
     GpuVec3d& Xcs,
     Scalar* chi);
 
-void constructQuadraticForm_Line(
+void CUGO_API constructQuadraticForm_Line(
     const GpuVecSe3d& se3,
     GpuVec1d& errors,
     const GpuVec<PointToLineMatch<double>>& measurements,
@@ -168,7 +168,7 @@ void constructQuadraticForm_Line(
     GpuLx1BlockVec& bl,
     GpuHplBlockMat& Hpl);
 
-void constructQuadraticForm_Plane(
+void CUGO_API constructQuadraticForm_Plane(
     const GpuVecSe3d& se3,
     GpuVec1d& errors,
     const GpuVec<PointToPlaneMatch<double>>& measurements,

--- a/src/macro.h
+++ b/src/macro.h
@@ -51,4 +51,29 @@ limitations under the License.
         }                                                                                          \
     }
 
+
+#ifdef WIN32
+    #ifdef BUILDING_DLL
+        #ifdef __GNUC__
+            #define GUGO_API __attribute__((dllexport))
+        #else
+            #define CUGO_API __declspec(dllexport)
+        #endif
+    #else
+        #ifdef __GNUC__
+            #define GUGO_API __attribute__((dllimport))
+        #else
+            #define CUGO_API __declspec(dllimport)
+        #endif
+    #endif
+#else
+    #if __GNUC__>=4
+        #define CUGO_API __attribute__((visibility("default")))
+    #else
+        #define CUGO_API
+    #endif
+#endif
+
+
+
 #endif // !__MACRO_H__


### PR DESCRIPTION
Updates the cmakelists to allow for shared builds - this is done via a conanfile option - `BUILD_CUGO_SHARED`. 

This PR also addresses the issue where symbols for the API weren't exported. This causes linker issues when building shared with hidden visibility.