### PR TITLE
Change naming to graph optimisation rather than BA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(CudaBundleAdjustment)
+project(CudaGraphOptimisation)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/include/ba_types.h
+++ b/include/ba_types.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef __CUDA_BUNDLE_ADJUSTMENT_TYPES_H__
-#define __CUDA_BUNDLE_ADJUSTMENT_TYPES_H__
+#ifndef __BA_TYPES_H__
+#define __BA_TYPES_H__
 
 #include "optimisable_graph.h"
 
@@ -203,4 +203,4 @@ public:
 
 } // namespace cugo
 
-#endif // !__CUDA_BUNDLE_ADJUSTMENT_TYPES_H__
+#endif // !__BA_TYPES_H__

--- a/include/cuda_graph_optimisation.h
+++ b/include/cuda_graph_optimisation.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef __CUDA_BUNDLE_ADJUSTMENT_H__
-#define __CUDA_BUNDLE_ADJUSTMENT_H__
+#ifndef __CUDA_GRAPH_OPTIMISATION_H__
+#define __CUDA_GRAPH_OPTIMISATION_H__
 
 #include "device_buffer.h"
 #include "device_matrix.h"
@@ -34,8 +34,8 @@ namespace cugo
 // forward declerations
 struct CameraParams;
 class BaseEdgeSet;
-class CudaBlockSolver;
-class CudaBundleAdjustmentImpl;
+class BlockSolver;
+class CudaGraphOptimisationImpl;
 class BaseVertexSet;
 class BaseVertex;
 
@@ -45,6 +45,25 @@ using UniquePtr = std::unique_ptr<T>;
 
 using EdgeSetVec = std::vector<BaseEdgeSet*>;
 using VertexSetVec = std::vector<BaseVertexSet*>;
+
+////////////////////////////////////////////////////////////////////////////////////
+// Camera parameters
+////////////////////////////////////////////////////////////////////////////////////
+
+/** @brief Camera parameters struct.
+ */
+struct CameraParams
+{
+    double fx; //!< focal length x (pixel)
+    double fy; //!< focal length y (pixel)
+    double cx; //!< principal point x (pixel)
+    double cy; //!< principal point y (pixel)
+    double bf; //!< stereo baseline times fx
+
+    /** @brief The constructor.
+     */
+    CameraParams() : fx(0), fy(0), cx(0), cy(0), bf(0) {}
+};
 
 ////////////////////////////////////////////////////////////////////////////////////
 // Statistics
@@ -108,12 +127,12 @@ It optimizes camera poses and landmarks (3D points) represented by a graph.
 added in the graph.
 
 */
-class CUGO_API CudaBundleAdjustment
+class CUGO_API CudaGraphOptimisation
 {
 public:
-    using Ptr = UniquePtr<CudaBundleAdjustmentImpl>;
+    using Ptr = UniquePtr<CudaGraphOptimisationImpl>;
 
-    /** @brief Creates an instance of CudaBundleAdjustment.
+    /** @brief Creates an instance of CudaGraphOptimisation.
      */
     static Ptr create();
 
@@ -136,7 +155,7 @@ public:
 
     /** @brief the destructor.
      */
-    virtual ~CudaBundleAdjustment();
+    virtual ~CudaGraphOptimisation();
 
     virtual EdgeSetVec& getEdgeSets() = 0;
 
@@ -150,15 +169,15 @@ public:
     virtual void setVerbose(bool status) = 0;
 };
 
-/** @brief Implementation of CudaBundleAdjustment.
+/** @brief Implementation of CudaGraphOptimisation.
  */
-class CUGO_API CudaBundleAdjustmentImpl : public CudaBundleAdjustment
+class CUGO_API CudaGraphOptimisationImpl : public CudaGraphOptimisation
 {
 public:
     /**
      * @brief constructor
      */
-    CudaBundleAdjustmentImpl();
+    CudaGraphOptimisationImpl();
 
     /** @brief adds a new graph to the optimiser with a custom edge
      */
@@ -197,7 +216,7 @@ public:
 
     void setVerbose(bool status) override { verbose = status; }
 
-    ~CudaBundleAdjustmentImpl();
+    ~CudaGraphOptimisationImpl();
 
 private:
     static inline double attenuation(double x) { return 1 - std::pow(2 * x - 1, 3); }
@@ -211,7 +230,7 @@ private:
     VertexSetVec vertexSets;
     EdgeSetVec edgeSets;
 
-    std::unique_ptr<CudaBlockSolver> solver_;
+    std::unique_ptr<BlockSolver> solver_;
     std::unique_ptr<CameraParams> camera_;
 
     BatchStatistics stats_;
@@ -220,4 +239,4 @@ private:
 
 } // namespace cugo
 
-#endif // !__CUDA_BUNDLE_ADJUSTMENT_H__
+#endif // !__CUDA_GRAPH_OPTIMISATION_H__

--- a/samples/sample_ba_from_file/main.cpp
+++ b/samples/sample_ba_from_file/main.cpp
@@ -14,9 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include <cuda_bundle_adjustment.h>
-#include <cuda_bundle_adjustment_types.h>
-#include <icp_types.h>
+#include <cuda_graph_optimisation.h>
+#include <ba_types.h>
 #include <opencv2/core.hpp>
 #include <optimisable_graph.h>
 
@@ -24,7 +23,7 @@ limitations under the License.
 #include <iostream>
 #include <vector>
 
-static cugo::CudaBundleAdjustment::Ptr readGraph(const std::string& filename);
+static cugo::CudaGraphOptimisation::Ptr readGraph(const std::string& filename);
 
 int main(int argc, char** argv)
 {
@@ -94,12 +93,12 @@ static inline cugo::maths::Vec<T, N> getArray(const cv::FileNode& node)
     return arr;
 }
 
-static cugo::CudaBundleAdjustment::Ptr readGraph(const std::string& filename)
+static cugo::CudaGraphOptimisation::Ptr readGraph(const std::string& filename)
 {
     cv::FileStorage fs(filename, cv::FileStorage::READ);
     CV_Assert(fs.isOpened());
 
-    auto optimizer = cugo::CudaBundleAdjustment::create();
+    auto optimizer = cugo::CudaGraphOptimisation::create();
 
     // read pose vertices
     cugo::PoseVertexSet* poseVertexSet = new cugo::PoseVertexSet(false);

--- a/samples/sample_comparison_with_g2o/main.cpp
+++ b/samples/sample_comparison_with_g2o/main.cpp
@@ -17,7 +17,7 @@ limitations under the License.
 #include "g2o/types/slam3d/vertex_pointxyz.h"
 
 #include <cuda_bundle_adjustment.h>
-#include <cuda_bundle_adjustment_types.h>
+#include <cuda_graph_optimisation.h>
 #include <g2o/core/block_solver.h>
 #include <g2o/core/optimization_algorithm_levenberg.h>
 #include <g2o/core/solver.h>
@@ -32,7 +32,7 @@ limitations under the License.
 #include <vector>
 
 using OptimizerCPU = g2o::SparseOptimizer;
-using OptimizerGPU = cugo::CudaBundleAdjustmentImpl;
+using OptimizerGPU = cugo::CudaGraphOptimisationImpl;
 
 static void readGraph(
     const std::string& filename,

--- a/src/block_solver.h
+++ b/src/block_solver.h
@@ -1,26 +1,25 @@
+#ifndef __BLOCK_SOLVER_H__
+#define __BLOCK_SOLVER_H__
 
-#ifndef __CUDA_BLOCK_SOLVER_IMPL_H__
-#define __CUDA_BLOCK_SOLVER_IMPL_H__
-
-#include "cuda_bundle_adjustment.h"
-#include "cuda_linear_solver.h"
 #include "device_buffer.h"
 #include "device_matrix.h"
 #include "sparse_block_matrix.h"
+#include "cuda_graph_optimisation.h"
+#include "cuda_linear_solver.h"
 
 #include <array>
 #include <vector>
-
 
 namespace cugo
 {
 // forward declerations
 class BaseEdge;
 class BaseEdgeSet;
+struct CameraParams;
 
 /** @brief Implementation of Block solver.
  */
-class CudaBlockSolver
+class BlockSolver
 {
 public:
     enum ProfileItem

--- a/src/cuda_graph_optimisation.cpp
+++ b/src/cuda_graph_optimisation.cpp
@@ -1,0 +1,203 @@
+/*
+Copyright 2020 Fixstars Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http ://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "cuda_graph_optimisation.h"
+
+#include "constants.h"
+#include "device_buffer.h"
+#include "device_matrix.h"
+#include "optimisable_graph.h"
+#include "sparse_block_matrix.h"
+#include "profile.h"
+
+#include <algorithm>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace cugo
+{
+
+EdgeSetVec& CudaGraphOptimisationImpl::getEdgeSets() { return edgeSets; }
+
+size_t CudaGraphOptimisationImpl::nVertices(const int id)
+{
+    assert(id < vertexSets.size());
+    return vertexSets[id]->size();
+}
+
+void CudaGraphOptimisationImpl::setCameraPrams(const CameraParams& camera)
+{
+    if (camera_)
+    {
+        camera_ = nullptr;
+    }
+    camera_ = std::make_unique<CameraParams>(camera);
+}
+
+void CudaGraphOptimisationImpl::initialize()
+{
+    solver_->initialize(camera_.get(), edgeSets, vertexSets);
+    stats_.clear();
+}
+
+void CudaGraphOptimisationImpl::optimize(int niterations)
+{
+    const int maxq = 10;
+    const double tau = 1e-5;
+
+    double nu = 2.0;
+    double lambda = 0.0;
+    double F = 0.0;
+    double cumTime = 0.0;
+
+    // Levenberg-Marquardt iteration
+    for (int iteration = 0; iteration < niterations; iteration++)
+    {
+        auto t0 = get_time_point();
+
+        if (iteration == 0)
+        {
+            solver_->buildStructure(edgeSets, vertexSets);
+        }
+
+        const double iniF = solver_->computeErrors(edgeSets, vertexSets);
+        F = iniF;
+
+        solver_->buildSystem(edgeSets, vertexSets);
+
+        if (iteration == 0)
+        {
+            lambda = tau * solver_->maxDiagonal();
+        }
+
+        int q = 0;
+        double rho = -1.0;
+        for (; q < maxq && rho < 0; q++)
+        {
+            solver_->push();
+
+            solver_->setLambda(lambda);
+
+            const bool success = solver_->solve();
+
+            solver_->update(vertexSets);
+            solver_->restoreDiagonal();
+
+            const double Fhat = solver_->computeErrors(edgeSets, vertexSets);
+            const double scale = solver_->computeScale(lambda) + 1e-3;
+            rho = success ? (F - Fhat) / scale : -1;
+
+            if (rho > 0)
+            {
+                lambda *= clamp(attenuation(rho), 1. / 3, 2. / 3);
+                nu = 2;
+                F = Fhat;
+                break;
+            }
+            else
+            {
+                lambda *= nu;
+                nu *= 2;
+                solver_->pop();
+            }
+        }
+
+        stats_.addStat({iteration, F});
+        if (verbose)
+        {
+            auto t1 = get_time_point();
+            auto dt = get_duration(t0, t1);
+            cumTime += dt;
+            printf(
+                "iteration= %i; time = %.5f [sec];  cum time= %.5f  chi2= %f;  lambda= %f   rho= "
+                "%f	nedges= %i\n",
+                iteration,
+                dt,
+                cumTime,
+                F,
+                lambda,
+                rho,
+                solver_->nedges());
+        }
+
+        if (q == maxq || rho <= 1e-4 || !std::isfinite(lambda))
+        {
+            break;
+        }
+    }
+
+    solver_->finalize(vertexSets);
+
+    solver_->getTimeProfile(timeProfile_);
+}
+
+void CudaGraphOptimisationImpl::clearEdgeSets()
+{
+    for (auto* edgeSet : edgeSets)
+    {
+        edgeSet->clearEdges();
+    }
+    edgeSets.clear();
+}
+
+void CudaGraphOptimisationImpl::clearVertexSets()
+{
+    for (BaseVertexSet* vertexSet : vertexSets)
+    {
+        if (!vertexSet->isMarginilised())
+        {
+            PoseVertexSet* poseVertexSet = dynamic_cast<PoseVertexSet*>(vertexSet);
+            for (auto* vertex : poseVertexSet->get())
+            {
+                delete vertex;
+                vertex = nullptr;
+            }
+        }
+        else
+        {
+            LandmarkVertexSet* lmVertexSet = dynamic_cast<LandmarkVertexSet*>(vertexSet);
+            for (auto* vertex : lmVertexSet->get())
+            {
+                delete vertex;
+                vertex = nullptr;
+            }
+        }
+    }
+    vertexSets.clear();
+}
+
+BatchStatistics& CudaGraphOptimisationImpl::batchStatistics() { return stats_; }
+
+const TimeProfile& CudaGraphOptimisationImpl::timeProfile() { return timeProfile_; }
+
+CudaGraphOptimisationImpl::CudaGraphOptimisationImpl() : solver_(std::make_unique<BlockSolver>())
+{
+}
+
+CudaGraphOptimisationImpl::~CudaGraphOptimisationImpl()
+{
+    clearVertexSets();
+    clearEdgeSets();
+}
+
+CudaGraphOptimisation::Ptr CudaGraphOptimisation::create()
+{
+    return std::make_unique<CudaGraphOptimisationImpl>();
+}
+
+CudaGraphOptimisation::~CudaGraphOptimisation() {}
+
+} // namespace cugo

--- a/src/fixed_vector.h
+++ b/src/fixed_vector.h
@@ -20,8 +20,6 @@ limitations under the License.
 #include "maths.h"
 #include "scalar.h"
 
-#include <cuda_runtime.h>
-
 #include <cassert>
 #include <cstdint>
 

--- a/src/measurements.h
+++ b/src/measurements.h
@@ -3,8 +3,6 @@
 
 #include "fixed_vector.h"
 
-#include <cuda_runtime.h>
-
 namespace cugo
 {
 /**

--- a/src/optimisable_graph.h
+++ b/src/optimisable_graph.h
@@ -3,10 +3,11 @@
 #define __OPTIMISABLE_GRAPH_H__
 
 #include "cuda/cuda_block_solver.h"
-#include "cuda_block_solver_impl.h"
-#include "cuda_bundle_adjustment.h"
+#include "cuda_graph_optimisation.h"
 #include "device_buffer.h"
 #include "device_matrix.h"
+#include "sparse_block_matrix.h"
+#include "block_solver.h"
 #include "maths.h"
 
 #include <Eigen/Core>
@@ -21,9 +22,6 @@
 
 namespace cugo
 {
-////////////////////////////////////////////////////////////////////////////////////
-// Type alias
-////////////////////////////////////////////////////////////////////////////////////
 
 template <class T>
 using Set = std::unordered_set<T>;
@@ -491,11 +489,11 @@ public:
             if (VertexSize == 1)
             {
                 edgeFlags.push_back(
-                    CudaBlockSolver::makeEdgeFlag(edge->getVertex(0)->isFixed(), false));
+                    BlockSolver::makeEdgeFlag(edge->getVertex(0)->isFixed(), false));
             }
             else
             {
-                edgeFlags.push_back(CudaBlockSolver::makeEdgeFlag(
+                edgeFlags.push_back(BlockSolver::makeEdgeFlag(
                     edge->getVertex(0)->isFixed(), edge->getVertex(1)->isFixed()));
             }
             edgeId++;
@@ -548,25 +546,6 @@ protected:
     GpuVec1i d_edge2Hpl;
 };
 
-////////////////////////////////////////////////////////////////////////////////////
-// Camera parameters
-////////////////////////////////////////////////////////////////////////////////////
-
-/** @brief Camera parameters struct.
- */
-struct CameraParams
-{
-    double fx; //!< focal length x (pixel)
-    double fy; //!< focal length y (pixel)
-    double cx; //!< principal point x (pixel)
-    double cy; //!< principal point y (pixel)
-    double bf; //!< stereo baseline times fx
-
-    /** @brief The constructor.
-     */
-    CameraParams() : fx(0), fy(0), cx(0), cy(0), bf(0) {}
-};
-;
 
 #include "optimisable_graph.hpp"
 

--- a/src/profile.h
+++ b/src/profile.h
@@ -1,0 +1,25 @@
+#ifndef __PROFILE_H__
+#define __PROFILE_H__
+
+#include <chrono>
+
+#include "cuda/cuda_block_solver.h"
+
+namespace cugo
+{
+
+using time_point = decltype(std::chrono::steady_clock::now());
+
+static inline time_point get_time_point()
+{
+    gpu::waitForKernelCompletion();
+    return std::chrono::steady_clock::now();
+}
+
+static inline double get_duration(const time_point& from, const time_point& to)
+{
+    return std::chrono::duration_cast<std::chrono::duration<double>>(to - from).count();
+}
+
+}
+#endif


### PR DESCRIPTION
The nature of the library is now more to do with graph optimisation rather than solely BA so the naming has been changed in this PR to reflect that. Also moved a few methods around - noticeably the block solver code is now in a separate file and the profiling code is also now moved into its own file.