### PR TITLE
Fix memory deallocation 

### DIFF
--- a/include/ba_types.h
+++ b/include/ba_types.h
@@ -32,30 +32,19 @@ namespace cugo
 class CUGO_API StereoEdgeSet : public EdgeSet<3, maths::Vec3d, Vec3d, PoseVertex, LandmarkVertex>
 {
 public:
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-
     StereoEdgeSet() {}
     ~StereoEdgeSet() {}
 
     Scalar computeError(const VertexSetVec& vertexSets, Scalar* chi) override
     {
-        assert(is_initialised == true);
-        assert(vertexSets.size() == 2);
         GpuVecSe3d poseEstimateData;
         GpuVec3d landmarkEstimateData;
-        for (auto* vertexSet : vertexSets)
-        {
-            if (!vertexSet->isMarginilised())
-            {
-                PoseVertexSet* poseVertexSet = static_cast<PoseVertexSet*>(vertexSet);
-                poseEstimateData = poseVertexSet->getDeviceEstimates();
-            }
-            else
-            {
-                LandmarkVertexSet* lmVertexSet = static_cast<LandmarkVertexSet*>(vertexSet);
-                landmarkEstimateData = lmVertexSet->getDeviceEstimates();
-            }
-        }
+
+        PoseVertexSet* poseVertexSet = static_cast<PoseVertexSet*>(vertexSets[0]);
+        poseEstimateData = poseVertexSet->getDeviceEstimates();
+        LandmarkVertexSet* lmVertexSet = static_cast<LandmarkVertexSet*>(vertexSets[1]);
+        landmarkEstimateData = lmVertexSet->getDeviceEstimates();
+
         return gpu::computeActiveErrors_<3>(
             poseEstimateData,
             landmarkEstimateData,
@@ -110,30 +99,19 @@ private:
 class CUGO_API MonoEdgeSet : public EdgeSet<2, maths::Vec2d, Vec2d, PoseVertex, LandmarkVertex>
 {
 public:
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-
     MonoEdgeSet() {}
     ~MonoEdgeSet() {}
 
     Scalar computeError(const VertexSetVec& vertexSets, Scalar* chi) override
     {
-        assert(is_initialised == true);
-        assert(vertexSets.size() == 2);
         GpuVecSe3d poseEstimateData;
         GpuVec3d landmarkEstimateData;
-        for (auto* vertexSet : vertexSets)
-        {
-            if (!vertexSet->isMarginilised())
-            {
-                PoseVertexSet* poseVertexSet = static_cast<PoseVertexSet*>(vertexSet);
-                poseEstimateData = poseVertexSet->getDeviceEstimates();
-            }
-            else
-            {
-                LandmarkVertexSet* lmVertexSet = static_cast<LandmarkVertexSet*>(vertexSet);
-                landmarkEstimateData = lmVertexSet->getDeviceEstimates();
-            }
-        }
+
+        PoseVertexSet* poseVertexSet = static_cast<PoseVertexSet*>(vertexSets[0]);
+        poseEstimateData = poseVertexSet->getDeviceEstimates();
+        LandmarkVertexSet* lmVertexSet = static_cast<LandmarkVertexSet*>(vertexSets[1]);
+        landmarkEstimateData = lmVertexSet->getDeviceEstimates();
+
         return gpu::computeActiveErrors_<2>(
             poseEstimateData,
             landmarkEstimateData,
@@ -185,6 +163,71 @@ public:
 private:
 };
 
+class CUGO_API DepthEdgeSet : public EdgeSet<3, maths::Vec3d, Vec3d, PoseVertex, LandmarkVertex>
+{
+public:
+    DepthEdgeSet() {}
+    ~DepthEdgeSet() {}
+
+    Scalar computeError(const VertexSetVec& vertexSets, Scalar* chi) override
+    {
+        GpuVecSe3d poseEstimateData;
+        GpuVec3d landmarkEstimateData;
+
+        PoseVertexSet* poseVertexSet = static_cast<PoseVertexSet*>(vertexSets[0]);
+        poseEstimateData = poseVertexSet->getDeviceEstimates();
+        LandmarkVertexSet* lmVertexSet = static_cast<LandmarkVertexSet*>(vertexSets[1]);
+        landmarkEstimateData = lmVertexSet->getDeviceEstimates();
+
+        return gpu::computeActiveErrors_DepthBa(
+            poseEstimateData,
+            landmarkEstimateData,
+            d_measurements,
+            d_omegas,
+            d_edge2PL,
+            outlierThreshold,
+            d_errors,
+            d_outliers,
+            d_Xcs,
+            chi);
+    }
+
+    void constructQuadraticForm(
+        const VertexSetVec& vertexSets,
+        GpuPxPBlockVec& Hpp,
+        GpuPx1BlockVec& bp,
+        GpuLxLBlockVec& Hll,
+        GpuLx1BlockVec& bl,
+        GpuHplBlockMat& Hpl) override
+    {
+        // NOTE: This assumes the pose vertex is of the SE3 form - also would break if more than one
+        // pose vertexset.
+        assert(is_initialised == true);
+        for (auto* vertexSet : vertexSets)
+        {
+            if (!vertexSet->isMarginilised())
+            {
+                // safe to be 100% sure this is a poseVertexSet?
+                PoseVertexSet* poseVertexSet = static_cast<PoseVertexSet*>(vertexSet);
+                GpuVecSe3d se3_data = poseVertexSet->getDeviceEstimates();
+                gpu::constructQuadraticForm_<3>(
+                    d_Xcs,
+                    se3_data,
+                    d_errors,
+                    d_omegas,
+                    d_edge2PL,
+                    d_edge2Hpl,
+                    d_edgeFlags,
+                    Hpp,
+                    bp,
+                    Hll,
+                    bl,
+                    Hpl);
+            }
+        }
+    }
+};
+
 /** @brief Edge with 2-dimensional measurement (monocular observation).
  */
 class CUGO_API MonoEdge : public Edge<2, maths::Vec2d, PoseVertex, LandmarkVertex>
@@ -198,6 +241,16 @@ public:
 /** @brief Edge with 3-dimensional measurement (stereo observation).
  */
 class CUGO_API StereoEdge : public Edge<3, maths::Vec3d, PoseVertex, LandmarkVertex>
+{
+public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+    void* getMeasurement() override { return static_cast<void*>(measurement.data()); }
+};
+
+/** @brief Edge with 3-dimensional measurement (depth observation).
+ */
+class CUGO_API DepthEdge : public Edge<3, maths::Vec3d, PoseVertex, LandmarkVertex>
 {
 public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/src/cuda/cuda_block_solver.h
+++ b/src/cuda/cuda_block_solver.h
@@ -129,6 +129,18 @@ Scalar CUGO_API computeActiveErrors_(
     GpuVec3d& Xcs,
     Scalar* chi);
 
+Scalar CUGO_API computeActiveErrors_DepthBa(
+    const GpuVecSe3d& poseEstimate,
+    const GpuVec3d& landmarkEstimate,
+    const GpuVec3d& measurements,
+    const GpuVec1d& omegas,
+    const GpuVec2i& edge2PL,
+    const Scalar errorThreshold,
+    GpuVec3d& errors,
+    GpuVec1i& outliers,
+    GpuVec3d& Xcs,
+    Scalar* chi);
+
 Scalar CUGO_API computeActiveErrors_Line(
     const GpuVecSe3d& poseEstimate,
     const GpuVec<PointToLineMatch<double>>& measurements,

--- a/src/cuda_graph_optimisation.cpp
+++ b/src/cuda_graph_optimisation.cpp
@@ -20,8 +20,8 @@ limitations under the License.
 #include "device_buffer.h"
 #include "device_matrix.h"
 #include "optimisable_graph.h"
-#include "sparse_block_matrix.h"
 #include "profile.h"
+#include "sparse_block_matrix.h"
 
 #include <algorithm>
 #include <unordered_map>
@@ -149,6 +149,8 @@ void CudaGraphOptimisationImpl::clearEdgeSets()
     for (auto* edgeSet : edgeSets)
     {
         edgeSet->clearEdges();
+        delete edgeSet;
+        edgeSet = nullptr;
     }
     edgeSets.clear();
 }
@@ -162,8 +164,11 @@ void CudaGraphOptimisationImpl::clearVertexSets()
             PoseVertexSet* poseVertexSet = dynamic_cast<PoseVertexSet*>(vertexSet);
             for (auto* vertex : poseVertexSet->get())
             {
-                delete vertex;
-                vertex = nullptr;
+                if (vertex)
+                {
+                    delete vertex;
+                    vertex = nullptr;
+                }
             }
         }
         else
@@ -171,10 +176,15 @@ void CudaGraphOptimisationImpl::clearVertexSets()
             LandmarkVertexSet* lmVertexSet = dynamic_cast<LandmarkVertexSet*>(vertexSet);
             for (auto* vertex : lmVertexSet->get())
             {
-                delete vertex;
-                vertex = nullptr;
+                if (vertex)
+                {
+                    delete vertex;
+                    vertex = nullptr;
+                }
             }
         }
+        delete vertexSet;
+        vertexSet = nullptr;
     }
     vertexSets.clear();
 }
@@ -183,9 +193,7 @@ BatchStatistics& CudaGraphOptimisationImpl::batchStatistics() { return stats_; }
 
 const TimeProfile& CudaGraphOptimisationImpl::timeProfile() { return timeProfile_; }
 
-CudaGraphOptimisationImpl::CudaGraphOptimisationImpl() : solver_(std::make_unique<BlockSolver>())
-{
-}
+CudaGraphOptimisationImpl::CudaGraphOptimisationImpl() : solver_(std::make_unique<BlockSolver>()) {}
 
 CudaGraphOptimisationImpl::~CudaGraphOptimisationImpl()
 {

--- a/src/optimisable_graph.h
+++ b/src/optimisable_graph.h
@@ -459,7 +459,18 @@ public:
         return edgeLevels;
     }
 
-    void clearEdges() override { edges.clear(); }
+    void clearEdges() override
+    {
+        for (BaseEdge* edge : edges)
+        {
+            if (edge)
+            {
+                delete edge;
+                edge = nullptr;
+            }
+        }
+        edges.clear();
+    }
 
 protected:
     std::unordered_set<BaseEdge*> edges;


### PR DESCRIPTION
Going with the notion that the cugo has ownership of all edges, vertices and sets once passed - and thus are all deleted by the library upon deconstruction. 