### PR TITLE
Optimise graph oiptimisation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -81,5 +81,11 @@
         "xtr1common": "cpp",
         "xtree": "cpp",
         "xutility": "cpp"
+    },
+    "[cpp]": {
+        "editor.formatOnType": false
+    },
+    "[c]": {
+        "editor.formatOnType": false
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -66,6 +66,20 @@
         "__tree": "cpp",
         "queue": "cpp",
         "stack": "cpp",
-        "filesystem": "cpp"
+        "filesystem": "cpp",
+        "concepts": "cpp",
+        "ios": "cpp",
+        "xfacet": "cpp",
+        "xhash": "cpp",
+        "xiosbase": "cpp",
+        "xlocale": "cpp",
+        "xlocinfo": "cpp",
+        "xlocnum": "cpp",
+        "xmemory": "cpp",
+        "xstddef": "cpp",
+        "xstring": "cpp",
+        "xtr1common": "cpp",
+        "xtree": "cpp",
+        "xutility": "cpp"
     }
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 option(USE_FLOAT32 "Use 32bit float in internal floating-point operations (default is 64bit float)" OFF)
 option(USE_TOOLKIT_10_2 "Enable CUDA Toolkit 10.2 compatibility." OFF)
 option(BUILD_CUGO_SHARED "Enable to building of cugo as a shared library" OFF)
+option(USE_ZERO_COPY "Enables zero copy for devices with integrated GPUs" OFF)
 
 add_subdirectory(src)
 
@@ -22,3 +23,4 @@ endif()
 unset(USE_FLOAT32 CACHE)
 unset(USE_TOOLKIT_10_2 CACHE)
 unset(BUILD_CUGO_SHARED CACHE)
+unset(USE_ZERO_COPY CACHE)

--- a/include/ba_types.h
+++ b/include/ba_types.h
@@ -17,8 +17,8 @@ limitations under the License.
 #ifndef __BA_TYPES_H__
 #define __BA_TYPES_H__
 
-#include "optimisable_graph.h"
 #include "macro.h"
+#include "optimisable_graph.h"
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -38,7 +38,7 @@ public:
     StereoEdgeSet() {}
     ~StereoEdgeSet() {}
 
-    Scalar computeError(const VertexSetVec& vertexSets, Scalar* chi) override
+    Scalar computeError(const VertexSetVec& vertexSets, Scalar* chi, cudaStream_t stream) override
     {
         GpuVecSe3d poseEstimateData;
         GpuVec3d landmarkEstimateData;
@@ -58,7 +58,8 @@ public:
             d_errors,
             d_outliers,
             d_Xcs,
-            chi);
+            chi,
+            stream);
     }
 
     void constructQuadraticForm(
@@ -67,7 +68,8 @@ public:
         GpuPx1BlockVec& bp,
         GpuLxLBlockVec& Hll,
         GpuLx1BlockVec& bl,
-        GpuHplBlockMat& Hpl) override
+        GpuHplBlockMat& Hpl,
+        cudaStream_t stream) override
     {
         // NOTE: This assumes the pose vertex is of the SE3 form - also would break if more than one
         // pose vertexset.
@@ -91,7 +93,8 @@ public:
                     bp,
                     Hll,
                     bl,
-                    Hpl);
+                    Hpl,
+                    stream);
             }
         }
     }
@@ -107,7 +110,7 @@ public:
     MonoEdgeSet() {}
     ~MonoEdgeSet() {}
 
-    Scalar computeError(const VertexSetVec& vertexSets, Scalar* chi) override
+    Scalar computeError(const VertexSetVec& vertexSets, Scalar* chi, cudaStream_t stream) override
     {
         GpuVecSe3d poseEstimateData;
         GpuVec3d landmarkEstimateData;
@@ -127,7 +130,8 @@ public:
             d_errors,
             d_outliers,
             d_Xcs,
-            chi);
+            chi,
+            stream);
     }
 
     void constructQuadraticForm(
@@ -136,7 +140,8 @@ public:
         GpuPx1BlockVec& bp,
         GpuLxLBlockVec& Hll,
         GpuLx1BlockVec& bl,
-        GpuHplBlockMat& Hpl) override
+        GpuHplBlockMat& Hpl,
+        cudaStream_t stream) override
     {
         // NOTE: This assumes the pose vertex is of the SE3 form - also would break if more than one
         // pose vertexset.
@@ -160,7 +165,8 @@ public:
                     bp,
                     Hll,
                     bl,
-                    Hpl);
+                    Hpl,
+                    stream);
             }
         }
     }
@@ -172,11 +178,11 @@ class CUGO_API DepthEdgeSet : public EdgeSet<3, maths::Vec3d, Vec3d, PoseVertex,
 {
 public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-    
+
     DepthEdgeSet() {}
     ~DepthEdgeSet() {}
 
-    Scalar computeError(const VertexSetVec& vertexSets, Scalar* chi) override
+    Scalar computeError(const VertexSetVec& vertexSets, Scalar* chi, cudaStream_t stream) override
     {
         GpuVecSe3d poseEstimateData;
         GpuVec3d landmarkEstimateData;
@@ -196,7 +202,8 @@ public:
             d_errors,
             d_outliers,
             d_Xcs,
-            chi);
+            chi,
+            stream);
     }
 
     void constructQuadraticForm(
@@ -205,7 +212,8 @@ public:
         GpuPx1BlockVec& bp,
         GpuLxLBlockVec& Hll,
         GpuLx1BlockVec& bl,
-        GpuHplBlockMat& Hpl) override
+        GpuHplBlockMat& Hpl,
+        cudaStream_t stream) override
     {
         // NOTE: This assumes the pose vertex is of the SE3 form - also would break if more than one
         // pose vertexset.
@@ -229,7 +237,8 @@ public:
                     bp,
                     Hll,
                     bl,
-                    Hpl);
+                    Hpl,
+                    stream);
             }
         }
     }

--- a/include/cuda_graph_optimisation.h
+++ b/include/cuda_graph_optimisation.h
@@ -235,6 +235,11 @@ private:
 
     BatchStatistics stats_;
     TimeProfile timeProfile_;
+
+    // cuda streams
+    std::array<cudaStream_t, 3> streams_;
+    int deviceId_;
+    cudaDeviceProp deviceProp_;
 };
 
 } // namespace cugo

--- a/include/icp_types.h
+++ b/include/icp_types.h
@@ -16,7 +16,7 @@
 
 namespace cugo
 {
-class CUGO_API LineEdgeSet 
+class CUGO_API LineEdgeSet
     : public EdgeSet<1, PointToLineMatch<double>, PointToLineMatch<double>, PoseVertex>
 {
 public:
@@ -25,7 +25,7 @@ public:
     LineEdgeSet() {}
     ~LineEdgeSet() {}
 
-    Scalar computeError(const VertexSetVec& vertexSets, Scalar* chi) override
+    Scalar computeError(const VertexSetVec& vertexSets, Scalar* chi, cudaStream_t stream) override
     {
         GpuVecSe3d estimates = static_cast<PoseVertexSet*>(vertexSets[0])->getDeviceEstimates();
         return gpu::computeActiveErrors_Line(
@@ -38,7 +38,8 @@ public:
         GpuPx1BlockVec& bp,
         GpuLxLBlockVec& Hll,
         GpuLx1BlockVec& bl,
-        GpuHplBlockMat& Hpl) override
+        GpuHplBlockMat& Hpl,
+        cudaStream_t stream) override
     {
         PoseVertexSet* poseVertexSet = static_cast<PoseVertexSet*>(vertexSets[0]);
         GpuVecSe3d se3_data = poseVertexSet->getDeviceEstimates();
@@ -70,11 +71,11 @@ public:
     PlaneEdgeSet() {}
     ~PlaneEdgeSet() {}
 
-    Scalar computeError(const VertexSetVec& vertexSets, Scalar* chi) override
+    Scalar computeError(const VertexSetVec& vertexSets, Scalar* chi, cudaStream_t stream) override
     {
         GpuVecSe3d estimates = static_cast<PoseVertexSet*>(vertexSets[0])->getDeviceEstimates();
         return gpu::computeActiveErrors_Plane(
-            estimates, d_measurements, d_omegas, d_edge2PL, d_errors, d_Xcs, chi);
+            estimates, d_measurements, d_omegas, d_edge2PL, d_errors, d_Xcs, chi, stream);
     }
 
     void constructQuadraticForm(
@@ -83,7 +84,8 @@ public:
         GpuPx1BlockVec& bp,
         GpuLxLBlockVec& Hll,
         GpuLx1BlockVec& bl,
-        GpuHplBlockMat& Hpl) override
+        GpuHplBlockMat& Hpl,
+        cudaStream_t stream) override
     {
         PoseVertexSet* poseVertexSet = static_cast<PoseVertexSet*>(vertexSets[0]);
         GpuVecSe3d se3_data = poseVertexSet->getDeviceEstimates();
@@ -99,7 +101,8 @@ public:
             bp,
             Hll,
             bl,
-            Hpl);
+            Hpl,
+            stream);
     }
 
 private:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,6 +41,9 @@ endif()
 if (USE_TOOLKIT_10_2)
 	list(APPEND CUGO_DEFINITIONS USE_TOOLKIT_10_2)
 endif()
+if (USE_ZERO_COPY)
+	list(APPEND CUGO_DEFINITIONS USE_ZERO_COPY)
+endif()
 
 file(GLOB_RECURSE srcs ./*.cpp ./*.h ./*.cu ${CUGO_INCLUDE_DIR}/*.h)
 

--- a/src/arena.h
+++ b/src/arena.h
@@ -1,0 +1,125 @@
+#pragma once
+
+#include "macro.h"
+
+#include <cuda_runtime.h>
+
+#include <cassert>
+#include <memory>
+
+namespace cugo
+{
+class Arena;
+
+template <typename T>
+class ArenaPtr
+{
+public:
+    ArenaPtr() = default;
+
+    ArenaPtr(size_t capacity, void* data, size_t offset)
+        : size_(0), data_((T*)data), capacity_(capacity), offset_(offset)
+    {
+    }
+    ~ArenaPtr() {}
+
+    void push_back(const T& data) noexcept
+    {
+        assert(size_ < capacity_);
+        T* data_ptr = data_ + size_;
+        memcpy(data_ptr, &data, sizeof(T));
+        ++size_;
+    }
+
+    void push_back(const T&& data) noexcept
+    {
+        assert(size_ < capacity_);
+        T* data_ptr = data_ + size_;
+        memcpy(data_ptr, &data, sizeof(T));
+        ++size_;
+    }
+
+    size_t size() const noexcept { return size_; }
+
+    void* data() noexcept { return static_cast<void*>(data_); }
+
+    void clear() noexcept { size_ = 0; }
+
+    size_t bufferOffset() const { return offset_; }
+
+private:
+    T* data_;
+    size_t size_;
+    size_t capacity_;
+    size_t offset_;
+};
+
+class Arena
+{
+public:
+    Arena() : arena_(nullptr), currSize_(0), capacity_(0) {}
+
+    Arena(size_t totalSize) : capacity_(totalSize), currSize_(0) { allocate(totalSize); }
+
+    Arena(const Arena& rhs) = delete;
+    Arena& operator=(const Arena& rhs) = delete;
+
+    ~Arena() noexcept
+    {
+        if (arena_)
+        {
+            destroy();
+        }
+    }
+
+    template <typename T>
+    std::unique_ptr<ArenaPtr<T>> reserve(size_t size) noexcept
+    {
+        size_t bytesInsert = size * sizeof(T);
+        assert(bytesInsert < capacity_);
+        void* arena_ptr = static_cast<char*>(arena_) + currSize_;
+        size_t offset = currSize_;
+        currSize_ += bytesInsert;
+        return std::make_unique<ArenaPtr<T>>(size, arena_ptr, offset);
+    }
+
+    void resize(size_t size) noexcept
+    {
+        clear();
+        if (!arena_ || size > capacity_)
+        {
+            allocate(size);
+        }
+    }
+
+    void clear() noexcept { currSize_ = 0; }
+
+    void* data() noexcept { return arena_; }
+
+private:
+    void allocate(size_t size) noexcept
+    {
+        if (arena_)
+        {
+            CUDA_CHECK(cudaFreeHost(arena_));
+            currSize_ = 0;
+        }
+        CUDA_CHECK(cudaMallocHost(&arena_, size));
+        capacity_ = size;
+    }
+
+    void destroy() noexcept
+    {
+        CUDA_CHECK(cudaFreeHost(arena_));
+        arena_ = nullptr;
+        capacity_ = 0;
+        currSize_ = 0;
+    }
+
+private:
+    void* arena_;
+    size_t currSize_;
+    size_t capacity_;
+};
+
+} // namespace cugo

--- a/src/async_vector.h
+++ b/src/async_vector.h
@@ -18,7 +18,7 @@ public:
     {
         if (data_)
         {
-            clear();
+            destroy();
         }
     }
 
@@ -52,8 +52,6 @@ public:
 
     void clear() noexcept
     {
-        // Keep the memory allocated and just reset back
-        // to the start of the allocation to save time.
         curr_data_ = data_;
         size_ = 0;
     }
@@ -75,7 +73,7 @@ public:
     size_t size() const noexcept { return size_; }
 
 private:
-    void allocate(size_t size)
+    void allocate(size_t size) noexcept
     {
         if (data_)
         {
@@ -85,6 +83,15 @@ private:
         CUDA_CHECK(cudaMallocHost(&data_, sizeof(T) * size));
         curr_data_ = data_;
         capacity_ = size;
+    }
+
+    void destroy() noexcept
+    {
+        CUDA_CHECK(cudaFreeHost(data_));
+        data_ = nullptr;
+        curr_data_ = nullptr;
+        capacity_ = 0;
+        size_ = 0;
     }
 
 private:

--- a/src/async_vector.h
+++ b/src/async_vector.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include "macro.h"
+
+#include <cassert>
+
+namespace cugo
+{
+
+template <typename T>
+class async_vector
+{
+public:
+    async_vector() : data_(nullptr), size_(0), capacity_(0), curr_data_(nullptr) {}
+    async_vector(size_t size) : size_(size) { allocate(size); }
+
+    ~async_vector()
+    {
+        if (data_)
+        {
+            clear();
+        }
+    }
+
+    void reserve(size_t size) noexcept
+    {
+        // only resize if we the new size is greater than the
+        // already existing size
+        if (!data_ || size > capacity_)
+        {
+            allocate(size);
+        }
+    }
+
+    void push_back(const T& data) noexcept
+    {
+        assert(data_);
+        assert(capacity_ > 0);
+        memcpy(curr_data_, &data, sizeof(T));
+        ++curr_data_;
+        ++size_;
+    }
+
+    void push_back(const T&& data) noexcept
+    {
+        assert(data_);
+        assert(capacity_ > 0);
+        memcpy(curr_data_, &data, sizeof(T));
+        ++curr_data_;
+        ++size_;
+    }
+
+    void clear() noexcept
+    {
+        // Keep the memory allocated and just reset back
+        // to the start of the allocation to save time.
+        curr_data_ = data_;
+        size_ = 0;
+    }
+
+    void* data() noexcept { return static_cast<void*>(data_); }
+
+    T& operator[](int index) noexcept
+    {
+        assert(index < capacity_);
+        return data_[index];
+    }
+
+    T& operator[](int index) const noexcept
+    {
+        assert(index < capacity_);
+        return data_[index];
+    }
+
+    size_t size() const noexcept { return size_; }
+
+private:
+    void allocate(size_t size)
+    {
+        if (data_)
+        {
+            CUDA_CHECK(cudaFreeHost(data_));
+            size_ = 0;
+        }
+        CUDA_CHECK(cudaMallocHost(&data_, sizeof(T) * size));
+        curr_data_ = data_;
+        capacity_ = size;
+    }
+
+private:
+    T* data_;
+    size_t size_;
+    size_t capacity_;
+    T* curr_data_;
+};
+
+} // namespace cugo

--- a/src/block_solver.h
+++ b/src/block_solver.h
@@ -1,11 +1,12 @@
 #ifndef __BLOCK_SOLVER_H__
 #define __BLOCK_SOLVER_H__
 
+#include "arena.h"
+#include "cuda_graph_optimisation.h"
+#include "cuda_linear_solver.h"
 #include "device_buffer.h"
 #include "device_matrix.h"
 #include "sparse_block_matrix.h"
-#include "cuda_graph_optimisation.h"
-#include "cuda_linear_solver.h"
 
 #include <array>
 #include <vector>
@@ -39,11 +40,20 @@ public:
     void
     initialize(CameraParams* camera, const EdgeSetVec& edgeSets, const VertexSetVec& vertexSets);
 
-    void buildStructure(const EdgeSetVec& edgeSets, const VertexSetVec& vertexSets);
+    void buildStructure(
+        const EdgeSetVec& edgeSets,
+        const VertexSetVec& vertexSets,
+        std::array<cudaStream_t, 3>& streams);
 
-    double computeErrors(const EdgeSetVec& edgeSets, const VertexSetVec& vertexSets);
+    double computeErrors(
+        const EdgeSetVec& edgeSets,
+        const VertexSetVec& vertexSets,
+        std::array<cudaStream_t, 3>& streams);
 
-    void buildSystem(const EdgeSetVec& edgeSets, const VertexSetVec& vertexSets);
+    void buildSystem(
+        const EdgeSetVec& edgeSets,
+        const VertexSetVec& vertexSets,
+        std::array<cudaStream_t, 3>& streams);
     double maxDiagonal();
 
     void setLambda(double lambda);
@@ -83,6 +93,8 @@ private:
 
     // graph components
     std::vector<BaseEdge*> baseEdges_;
+
+    Arena hBlockPosArena;
 
     // block matrices
     HplSparseBlockMatrix Hpl_;

--- a/src/cuda/cuda_block_solver.h
+++ b/src/cuda/cuda_block_solver.h
@@ -38,7 +38,11 @@ void waitForKernelCompletion();
 void setCameraParameters(const Scalar* camera);
 
 void buildHplStructure(
-    GpuVec3i& blockpos, GpuHplBlockMat& Hpl, GpuVec1i& indexPL, GpuVec1i& nnzPerCol);
+    GpuVec3i& blockpos,
+    GpuHplBlockMat& Hpl,
+    GpuVec1i& indexPL,
+    GpuVec1i& nnzPerCol,
+    cudaStream_t stream);
 
 void findHschureMulBlockIndices(
     const GpuHplBlockMat& Hpl, const GpuHscBlockMat& Hsc, GpuVec3i& mulBlockIds);
@@ -114,7 +118,8 @@ void CUGO_API constructQuadraticForm_(
     GpuPx1BlockVec& bp,
     GpuLxLBlockVec& Hll,
     GpuLx1BlockVec& bl,
-    GpuHplBlockMat& Hpl);
+    GpuHplBlockMat& Hpl,
+    cudaStream_t stream);
 
 template <int M>
 Scalar CUGO_API computeActiveErrors_(
@@ -127,7 +132,8 @@ Scalar CUGO_API computeActiveErrors_(
     GpuVecxd<M>& errors,
     GpuVec1i& outliers,
     GpuVec3d& Xcs,
-    Scalar* chi);
+    Scalar* chi,
+    cudaStream_t stream);
 
 Scalar CUGO_API computeActiveErrors_DepthBa(
     const GpuVecSe3d& poseEstimate,
@@ -139,7 +145,8 @@ Scalar CUGO_API computeActiveErrors_DepthBa(
     GpuVec3d& errors,
     GpuVec1i& outliers,
     GpuVec3d& Xcs,
-    Scalar* chi);
+    Scalar* chi,
+    cudaStream_t stream);
 
 Scalar CUGO_API computeActiveErrors_Line(
     const GpuVecSe3d& poseEstimate,
@@ -157,7 +164,8 @@ Scalar CUGO_API computeActiveErrors_Plane(
     const GpuVec2i& edge2PL,
     GpuVec1d& errors,
     GpuVec3d& Xcs,
-    Scalar* chi);
+    Scalar* chi,
+    cudaStream_t stream);
 
 void CUGO_API constructQuadraticForm_Line(
     const GpuVecSe3d& se3,
@@ -185,7 +193,8 @@ void CUGO_API constructQuadraticForm_Plane(
     GpuPx1BlockVec& bp,
     GpuLxLBlockVec& Hll,
     GpuLx1BlockVec& bl,
-    GpuHplBlockMat& Hpl);
+    GpuHplBlockMat& Hpl,
+    cudaStream_t stream);
 
 } // namespace gpu
 

--- a/src/cuda_device.h
+++ b/src/cuda_device.h
@@ -1,0 +1,240 @@
+#pragma once
+
+#include "macro.h"
+
+#include <cuda_runtime.h>
+
+#include <cstdint>
+#include <cstdio>
+
+namespace cugo
+{
+
+static const char* _cudaGetErrorEnum(cudaError_t error) { return cudaGetErrorName(error); }
+
+// Beginning of GPU Architecture definitions
+inline int _ConvertSMVer2Cores(int major, int minor)
+{
+    // Defines for GPU Architecture types (using the SM version to determine
+    // the # of cores per SM
+    typedef struct
+    {
+        int SM; // 0xMm (hexidecimal notation), M = SM Major version,
+        // and m = SM minor version
+        int Cores;
+    } sSMtoCores;
+
+    sSMtoCores nGpuArchCoresPerSM[] = {
+        {0x30, 192},
+        {0x32, 192},
+        {0x35, 192},
+        {0x37, 192},
+        {0x50, 128},
+        {0x52, 128},
+        {0x53, 128},
+        {0x60, 64},
+        {0x61, 128},
+        {0x62, 128},
+        {0x70, 64},
+        {0x72, 64},
+        {0x75, 64},
+        {0x80, 64},
+        {0x86, 128},
+        {0x87, 128},
+        {-1, -1}};
+
+    int index = 0;
+
+    while (nGpuArchCoresPerSM[index].SM != -1)
+    {
+        if (nGpuArchCoresPerSM[index].SM == ((major << 4) + minor))
+        {
+            return nGpuArchCoresPerSM[index].Cores;
+        }
+
+        index++;
+    }
+
+    // If we don't find the values, we default use the previous one
+    // to run properly
+    printf(
+        "MapSMtoCores for SM %d.%d is undefined."
+        "  Default to use %d Cores/SM\n",
+        major,
+        minor,
+        nGpuArchCoresPerSM[index - 1].Cores);
+    return nGpuArchCoresPerSM[index - 1].Cores;
+}
+
+inline const char* _ConvertSMVer2ArchName(int major, int minor)
+{
+    // Defines for GPU Architecture types (using the SM version to determine
+    // the GPU Arch name)
+    typedef struct
+    {
+        int SM; // 0xMm (hexidecimal notation), M = SM Major version,
+        // and m = SM minor version
+        const char* name;
+    } sSMtoArchName;
+
+    sSMtoArchName nGpuArchNameSM[] = {
+        {0x30, "Kepler"},
+        {0x32, "Kepler"},
+        {0x35, "Kepler"},
+        {0x37, "Kepler"},
+        {0x50, "Maxwell"},
+        {0x52, "Maxwell"},
+        {0x53, "Maxwell"},
+        {0x60, "Pascal"},
+        {0x61, "Pascal"},
+        {0x62, "Pascal"},
+        {0x70, "Volta"},
+        {0x72, "Xavier"},
+        {0x75, "Turing"},
+        {0x80, "Ampere"},
+        {0x86, "Ampere"},
+        {-1, "Graphics Device"}};
+
+    int index = 0;
+
+    while (nGpuArchNameSM[index].SM != -1)
+    {
+        if (nGpuArchNameSM[index].SM == ((major << 4) + minor))
+        {
+            return nGpuArchNameSM[index].name;
+        }
+
+        index++;
+    }
+
+    // If we don't find the values, we default use the previous one
+    // to run properly
+    printf(
+        "MapSMtoArchName for SM %d.%d is undefined."
+        "  Default to use %s\n",
+        major,
+        minor,
+        nGpuArchNameSM[index - 1].name);
+    return nGpuArchNameSM[index - 1].name;
+}
+
+// This function returns the best GPU (with maximum GFLOPS)
+inline int gpuGetMaxGflopsDeviceId()
+{
+    int current_device = 0, sm_per_multiproc = 0;
+    int max_perf_device = 0;
+    int device_count = 0;
+    int devices_prohibited = 0;
+
+    uint64_t max_compute_perf = 0;
+    CUDA_CHECK(cudaGetDeviceCount(&device_count));
+
+    if (device_count == 0)
+    {
+        fprintf(
+            stderr,
+            "gpuGetMaxGflopsDeviceId() CUDA error:"
+            " no devices supporting CUDA.\n");
+        exit(EXIT_FAILURE);
+    }
+
+    // Find the best CUDA capable GPU device
+    current_device = 0;
+
+    while (current_device < device_count)
+    {
+        int computeMode = -1, major = 0, minor = 0;
+        CUDA_CHECK(cudaDeviceGetAttribute(&computeMode, cudaDevAttrComputeMode, current_device));
+        CUDA_CHECK(
+            cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, current_device));
+        CUDA_CHECK(
+            cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, current_device));
+
+        // If this GPU is not running on Compute Mode prohibited,
+        // then we can add it to the list
+        if (computeMode != cudaComputeModeProhibited)
+        {
+            if (major == 9999 && minor == 9999)
+            {
+                sm_per_multiproc = 1;
+            }
+            else
+            {
+                sm_per_multiproc = _ConvertSMVer2Cores(major, minor);
+            }
+            int multiProcessorCount = 0, clockRate = 0;
+            CUDA_CHECK(cudaDeviceGetAttribute(
+                &multiProcessorCount, cudaDevAttrMultiProcessorCount, current_device));
+            cudaError_t result =
+                cudaDeviceGetAttribute(&clockRate, cudaDevAttrClockRate, current_device);
+            if (result != cudaSuccess)
+            {
+                // If cudaDevAttrClockRate attribute is not supported we
+                // set clockRate as 1, to consider GPU with most SMs and CUDA Cores.
+                if (result == cudaErrorInvalidValue)
+                {
+                    clockRate = 1;
+                }
+                else
+                {
+                    fprintf(
+                        stderr,
+                        "CUDA error at %s:%d code=%d(%s) \n",
+                        __FILE__,
+                        __LINE__,
+                        static_cast<unsigned int>(result),
+                        _cudaGetErrorEnum(result));
+                    exit(EXIT_FAILURE);
+                }
+            }
+            uint64_t compute_perf = (uint64_t)multiProcessorCount * sm_per_multiproc * clockRate;
+
+            if (compute_perf > max_compute_perf)
+            {
+                max_compute_perf = compute_perf;
+                max_perf_device = current_device;
+            }
+        }
+        else
+        {
+            devices_prohibited++;
+        }
+
+        ++current_device;
+    }
+
+    if (devices_prohibited == device_count)
+    {
+        fprintf(
+            stderr,
+            "gpuGetMaxGflopsDeviceId() CUDA error:"
+            " all devices have compute mode prohibited.\n");
+        exit(EXIT_FAILURE);
+    }
+
+    return max_perf_device;
+}
+
+
+// Initialization code to find the best CUDA Device
+inline int findCudaDevice()
+{
+    int devID = 0;
+
+    // pick the device with highest Gflops/s
+    devID = gpuGetMaxGflopsDeviceId();
+    CUDA_CHECK(cudaSetDevice(devID));
+    int major = 0, minor = 0;
+    CUDA_CHECK(cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, devID));
+    CUDA_CHECK(cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, devID));
+    printf(
+        "GPU Device % d : \"% s\" with compute capability % d.% d\n\n",
+        devID,
+        _ConvertSMVer2ArchName(major, minor),
+        major,
+        minor);
+
+    return devID;
+}
+
+} // namespace cugo

--- a/src/cuda_graph_optimisation.cpp
+++ b/src/cuda_graph_optimisation.cpp
@@ -146,11 +146,26 @@ void CudaGraphOptimisationImpl::optimize(int niterations)
 
 void CudaGraphOptimisationImpl::clearEdgeSets()
 {
+    for (BaseEdgeSet* edgeSet : edgeSets)
+    {
+        if (edgeSet)
+        {
+            edgeSet->clearEdges();
+            delete edgeSet;
+            edgeSet = nullptr;
+        }
+    }
     edgeSets.clear();
 }
 
 void CudaGraphOptimisationImpl::clearVertexSets()
 {
+    for (BaseVertexSet* vertexSet : vertexSets)
+    {
+        vertexSet->clearVertices();
+        delete vertexSet;
+        vertexSet = nullptr;
+    }
     vertexSets.clear();
 }
 
@@ -160,7 +175,13 @@ const TimeProfile& CudaGraphOptimisationImpl::timeProfile() { return timeProfile
 
 CudaGraphOptimisationImpl::CudaGraphOptimisationImpl() : solver_(std::make_unique<BlockSolver>()) {}
 
-CudaGraphOptimisationImpl::~CudaGraphOptimisationImpl() {}
+CudaGraphOptimisationImpl::~CudaGraphOptimisationImpl()
+{
+#ifdef CUGO_MEMORY_CLEANUP
+    clearVertexSets();
+    clearEdgeSets();
+#endif
+}
 
 CudaGraphOptimisation::Ptr CudaGraphOptimisation::create()
 {

--- a/src/cuda_graph_optimisation.cpp
+++ b/src/cuda_graph_optimisation.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 #include "cuda_graph_optimisation.h"
 
 #include "constants.h"
+#include "cuda_device.h"
 #include "device_buffer.h"
 #include "device_matrix.h"
 #include "optimisable_graph.h"
@@ -70,13 +71,13 @@ void CudaGraphOptimisationImpl::optimize(int niterations)
 
         if (iteration == 0)
         {
-            solver_->buildStructure(edgeSets, vertexSets);
+            solver_->buildStructure(edgeSets, vertexSets, streams_);
         }
 
-        const double iniF = solver_->computeErrors(edgeSets, vertexSets);
+        const double iniF = solver_->computeErrors(edgeSets, vertexSets, streams_);
         F = iniF;
 
-        solver_->buildSystem(edgeSets, vertexSets);
+        solver_->buildSystem(edgeSets, vertexSets, streams_);
 
         if (iteration == 0)
         {
@@ -96,7 +97,7 @@ void CudaGraphOptimisationImpl::optimize(int niterations)
             solver_->update(vertexSets);
             solver_->restoreDiagonal();
 
-            const double Fhat = solver_->computeErrors(edgeSets, vertexSets);
+            const double Fhat = solver_->computeErrors(edgeSets, vertexSets, streams_);
             const double scale = solver_->computeScale(lambda) + 1e-3;
             rho = success ? (F - Fhat) / scale : -1;
 
@@ -133,7 +134,7 @@ void CudaGraphOptimisationImpl::optimize(int niterations)
                 solver_->nedges());
         }
 
-        if (q == maxq || rho <= 1e-4 || !std::isfinite(lambda))
+        if (q == maxq || rho == 0 || !std::isfinite(lambda))
         {
             break;
         }
@@ -144,44 +145,35 @@ void CudaGraphOptimisationImpl::optimize(int niterations)
     solver_->getTimeProfile(timeProfile_);
 }
 
-void CudaGraphOptimisationImpl::clearEdgeSets()
-{
-    for (BaseEdgeSet* edgeSet : edgeSets)
-    {
-        if (edgeSet)
-        {
-            edgeSet->clearEdges();
-            delete edgeSet;
-            edgeSet = nullptr;
-        }
-    }
-    edgeSets.clear();
-}
+void CudaGraphOptimisationImpl::clearEdgeSets() { edgeSets.clear(); }
 
-void CudaGraphOptimisationImpl::clearVertexSets()
-{
-    for (BaseVertexSet* vertexSet : vertexSets)
-    {
-        vertexSet->clearVertices();
-        delete vertexSet;
-        vertexSet = nullptr;
-    }
-    vertexSets.clear();
-}
+void CudaGraphOptimisationImpl::clearVertexSets() { vertexSets.clear(); }
 
 BatchStatistics& CudaGraphOptimisationImpl::batchStatistics() { return stats_; }
 
 const TimeProfile& CudaGraphOptimisationImpl::timeProfile() { return timeProfile_; }
 
-CudaGraphOptimisationImpl::CudaGraphOptimisationImpl() : solver_(std::make_unique<BlockSolver>()) {}
-
-CudaGraphOptimisationImpl::~CudaGraphOptimisationImpl()
+CudaGraphOptimisationImpl::CudaGraphOptimisationImpl() : solver_(std::make_unique<BlockSolver>())
 {
-#ifdef CUGO_MEMORY_CLEANUP
-    clearVertexSets();
-    clearEdgeSets();
+    deviceId_ = findCudaDevice();
+    CUDA_CHECK(cudaGetDeviceProperties(&deviceProp_, deviceId_));
+
+#ifndef USE_ZERO_COPY
+    for (int i = 0; i < streams_.size(); ++i)
+    {
+        CUDA_CHECK(cudaStreamCreate(&streams_[i]));
+    }
+#else
+    // use default stream if using zero copy as copying data to the device
+    // async is no longer required.
+    for (int i = 0; i < streams_.size(); ++i)
+    {
+        streams_[i] = 0;
+    }
 #endif
 }
+
+CudaGraphOptimisationImpl::~CudaGraphOptimisationImpl() {}
 
 CudaGraphOptimisation::Ptr CudaGraphOptimisation::create()
 {

--- a/src/optimisable_graph.h
+++ b/src/optimisable_graph.h
@@ -2,6 +2,7 @@
 #ifndef __OPTIMISABLE_GRAPH_H__
 #define __OPTIMISABLE_GRAPH_H__
 
+#include "arena.h"
 #include "async_vector.h"
 #include "block_solver.h"
 #include "cuda/cuda_block_solver.h"
@@ -13,6 +14,7 @@
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <string>
@@ -205,6 +207,7 @@ public:
     void clearEstimates() override
     {
         estimates.clear();
+        vertices.clear();
         activeSize = 0;
     }
 
@@ -352,13 +355,13 @@ public:
 
     virtual const int dim() const = 0;
 
-    virtual cugo::async_vector<HplBlockPos>& getHessianBlockPos() = 0;
+    virtual void* getHessianBlockPos() = 0;
 
     virtual size_t getHessianBlockPosSize() const = 0;
 
-    virtual void init(int& edgeId, bool doSchur) = 0;
+    virtual void init(Arena& hBlockPosArena, int& edgeId, cudaStream_t stream, bool doSchur) = 0;
 
-    virtual void mapDevice(int* edge2HData) = 0;
+    virtual void mapDevice(int* edge2HData, cudaStream_t stream) = 0;
 
     virtual void clearDevice() = 0;
 
@@ -373,11 +376,15 @@ public:
         GpuPx1BlockVec& bp,
         GpuLxLBlockVec& Hll,
         GpuLx1BlockVec& bl,
-        GpuHplBlockMat& Hpl)
+        GpuHplBlockMat& Hpl,
+        cudaStream_t stream)
     {
     }
 
-    virtual Scalar computeError(const VertexSetVec& vertexSets, Scalar* chi) { return 0; }
+    virtual Scalar computeError(const VertexSetVec& vertexSets, Scalar* chi, cudaStream_t stream)
+    {
+        return 0;
+    }
 
     virtual void setRobustKernel(BaseRobustKernel* kernel) = 0;
     virtual BaseRobustKernel* robustKernel() = 0;
@@ -433,9 +440,9 @@ public:
 
     const std::unordered_set<BaseEdge*>& get() override { return edges; }
 
-    cugo::async_vector<HplBlockPos>& getHessianBlockPos() override { return hessianBlockPos; }
+    void* getHessianBlockPos() override { return hessianBlockPos->data(); }
 
-    size_t getHessianBlockPosSize() const override { return hessianBlockPos.size(); }
+    size_t getHessianBlockPosSize() const override { return hessianBlockPos->size(); }
 
     const int dim() const override { return DIM; }
 
@@ -465,6 +472,7 @@ protected:
     BaseRobustKernel* kernel;
     Scalar outlierThreshold;
     std::vector<int> edgeLevels;
+    size_t totalBufferSize_ = 0;
 
 public:
     // device side
@@ -472,15 +480,25 @@ public:
     using ErrorVec = typename std::conditional<(DIM == 1), GpuVec1d, GpuVec<VecNd<DIM>>>::type;
     using MeasurementVec = GpuVec<GpuMeasurementType>;
 
-    void init(int& edgeId, bool doSchur) override
+    void init(Arena& hBlockPosArena, int& edgeId, cudaStream_t stream, bool doSchur) override
     {
         size_t edgeSize = edges.size();
+        totalBufferSize_ = sizeof(MeasurementType) * edgeSize + sizeof(Scalar) * edgeSize +
+            sizeof(VIndex) * edgeSize + sizeof(uint8_t) * edgeSize;
 
-        measurements.reserve(edgeSize);
-        omegas.reserve(edgeSize);
-        edge2PL.reserve(edgeSize);
-        edgeFlags.reserve(edgeSize);
-        hessianBlockPos.reserve(edgeSize);
+        // allocate more buffers than needed to reduce the need
+        // for resizing.
+        arena.resize(totalBufferSize_ * 2);
+        measurements = arena.reserve<MeasurementType>(edgeSize);
+        omegas = arena.reserve<Scalar>(edgeSize);
+        edge2PL = arena.reserve<VIndex>(edgeSize);
+        edgeFlags = arena.reserve<uint8_t>(edgeSize);
+
+        // all heassian block positions are also
+        if (doSchur)
+        {
+            hessianBlockPos = hBlockPosArena.reserve<HplBlockPos>(edgeSize);
+        }
 
         for (BaseEdge* edge : edges)
         {
@@ -500,65 +518,72 @@ public:
                     assert(vec[1] != -1);
                 }
             }
-            edge2PL.push_back(vec);
+            edge2PL->push_back(vec);
 
             if (doSchur && !edge->allVerticesFixed())
             {
-                hessianBlockPos.push_back({vec[0], vec[1], edgeId});
+                hessianBlockPos->push_back({vec[0], vec[1], edgeId});
             }
 
-            omegas.push_back(ScalarCast(edge->getInformation()));
-            measurements.push_back(*(static_cast<MeasurementType*>(edge->getMeasurement())));
+            omegas->push_back(ScalarCast(edge->getInformation()));
+            measurements->push_back(*(static_cast<MeasurementType*>(edge->getMeasurement())));
 
             if (VertexSize == 1)
             {
-                edgeFlags.push_back(
+                edgeFlags->push_back(
                     BlockSolver::makeEdgeFlag(edge->getVertex(0)->isFixed(), false));
             }
             else
             {
-                edgeFlags.push_back(BlockSolver::makeEdgeFlag(
+                edgeFlags->push_back(BlockSolver::makeEdgeFlag(
                     edge->getVertex(0)->isFixed(), edge->getVertex(1)->isFixed()));
             }
             edgeId++;
         }
     }
 
-    void mapDevice(int* edge2HData) override
+    void mapDevice(int* edge2HData, cudaStream_t stream) override
     {
         size_t edgeSize = edges.size();
-        d_measurements.assign(edgeSize, measurements.data());
+
+        // buffers filled by the gpu kernels.
         d_errors.resize(edgeSize);
         d_outliers.resize(edgeSize);
-        d_omegas.assign(edgeSize, omegas.data());
         d_Xcs.resize(edgeSize);
-        d_edgeFlags.assign(edgeSize, edgeFlags.data());
-        d_edge2PL.assign(edgeSize, edge2PL.data());
+
+        if (outlierThreshold > 0.0)
+        {
+            d_outlierThreshold.assign(1, &outlierThreshold);
+        }
         if (edge2HData)
         {
             d_edge2Hpl.map(edgeSize, edge2HData);
         }
-        d_outlierThreshold.assign(1, &outlierThreshold);
+
+        // The main mega buffer which contains all of the data used
+        // in optimising the graph - transferring one large buffer async
+        // is far more optimal than transferring multiple smaller buffers
+        d_dataBuffer.assignAsync(totalBufferSize_, arena.data(), stream);
+
+        d_omegas.offset(d_dataBuffer, edgeSize, omegas->bufferOffset());
+        d_edgeFlags.offset(d_dataBuffer, edgeSize, edgeFlags->bufferOffset());
+        d_edge2PL.offset(d_dataBuffer, edgeSize, edge2PL->bufferOffset());
+        d_measurements.offset(d_dataBuffer, edgeSize, measurements->bufferOffset());
     }
 
-    void clearDevice() override
-    {
-        hessianBlockPos.clear();
-        omegas.clear();
-        edge2PL.clear();
-        edgeFlags.clear();
-        measurements.clear();
-    }
+    void clearDevice() override { arena.clear(); }
 
 protected:
     // cpu - using pinned memory for async access
-    cugo::async_vector<Scalar> omegas;
-    cugo::async_vector<VIndex> edge2PL;
-    cugo::async_vector<uint8_t> edgeFlags;
-    cugo::async_vector<MeasurementType> measurements;
-    cugo::async_vector<HplBlockPos> hessianBlockPos;
+    Arena arena;
+    std::unique_ptr<ArenaPtr<Scalar>> omegas;
+    std::unique_ptr<ArenaPtr<VIndex>> edge2PL;
+    std::unique_ptr<ArenaPtr<uint8_t>> edgeFlags;
+    std::unique_ptr<ArenaPtr<MeasurementType>> measurements;
+    std::unique_ptr<ArenaPtr<HplBlockPos>> hessianBlockPos;
 
     // device
+    GpuVec<uint8_t> d_dataBuffer;
     GpuVec3d d_Xcs;
     GpuVec1d d_omegas;
     MeasurementVec d_measurements;


### PR DESCRIPTION
This adds numerous changes to improve perforrmance across the whole library.
Adds the following:
- Zero copy for devices that have integrated GPUs such as the Jetson.
- MemcpyAsync and streams - this will require more work to see if more CPU work can be carried out whilst uploading data to the device.
- Edge data (omegas, measurements, etc.) now allocated in one large Arena - thus reducing the number of transfers required.
- Async vector aded which allocates pinned memory required for Async memcpy's
- Using cooperative thread functions for ComputeError kernal which allows more control over the warps and eliminates stalling of threads.
- FIxed vertices not being cleared before a new round of optimisation which was leading to the edge size going through the roof and slowing down the runtime due to running out of device memory