### PR TITLE
Improve pointer alignmnet in Arena allocator to fix errors in CUDA

### DIFF
--- a/src/block_solver.cpp
+++ b/src/block_solver.cpp
@@ -146,7 +146,7 @@ void BlockSolver::buildStructure(
 
     if (doSchur)
     {
-        hBlockPosArena.resize(10000);
+        hBlockPosArena.resize(HBLOCKPOS_ARENA_SIZE);
     }
 
     for (BaseEdgeSet* edgeSet : edgeSets)

--- a/src/block_solver.h
+++ b/src/block_solver.h
@@ -39,6 +39,8 @@ public:
         PROF_ITEM_NUM
     };
 
+    static constexpr int HBLOCKPOS_ARENA_SIZE = 10000;
+
     BlockSolver() = delete;
     BlockSolver(GraphOptimisationOptions& options) : options(options), doSchur(false), nedges_(0) {}
 

--- a/src/optimisable_graph.h
+++ b/src/optimisable_graph.h
@@ -663,7 +663,7 @@ protected:
     std::unordered_set<BaseEdge*> edges;
     BaseRobustKernel* kernel;
     Scalar outlierThreshold;
-    std::vector<int> edgeLevels;
+    std::vector<int> edgeOutliers;
     size_t totalBufferSize_;
     Information info_;
 
@@ -688,11 +688,11 @@ protected:
     /// A memory pool for allocating a chunk of memory for all edge set data. Uses pinned memory to
     /// allow for async mem copies.
     Arena arena;
-    std::unique_ptr<ArenaPtr<Scalar>> omega;
-    std::unique_ptr<ArenaPtr<VIndex>> edge2PL;
-    std::unique_ptr<ArenaPtr<uint8_t>> edgeFlags;
-    std::unique_ptr<ArenaPtr<MeasurementType>> measurements;
-    std::unique_ptr<ArenaPtr<HplBlockPos>> hessianBlockPos;
+    std::unique_ptr<ArenaPool<Scalar>> omega;
+    std::unique_ptr<ArenaPool<VIndex>> edge2PL;
+    std::unique_ptr<ArenaPool<uint8_t>> edgeFlags;
+    std::unique_ptr<ArenaPool<MeasurementType>> measurements;
+    std::unique_ptr<ArenaPool<HplBlockPos>> hessianBlockPos;
 
     // device
     GpuVec<uint8_t> d_dataBuffer;

--- a/src/optimisable_graph.hpp
+++ b/src/optimisable_graph.hpp
@@ -235,7 +235,7 @@ void VertexSet<T, E, D>::clearEstimates() noexcept
 template <typename T, typename E, typename D>
 void VertexSet<T, E, D>::clearVertices() noexcept
 {
-    vertices.clear();
+    vertexMap.clear();
 }
 
 // edge class functioms
@@ -364,9 +364,9 @@ std::vector<int>& EdgeSet<DIM, E, F, VertexTypes...>::outliers()
         outlierThreshold > 0.0 &&
         "No error threshold set for this edgeSet, thus no outliers will have been calcuated "
         "during graph optimisation.");
-    edgeLevels.resize(edges.size());
-    d_outliers.copyTo(edgeLevels.data());
-    return edgeLevels;
+    edgeOutliers.resize(edges.size());
+    d_outliers.copyTo(edgeOutliers.data());
+    return edgeOutliers;
 }
 
 template <int DIM, typename E, typename F, typename... VertexTypes>
@@ -417,7 +417,7 @@ void EdgeSet<DIM, E, F, VertexTypes...>::init(
         totalBufferSize_ += sizeof(Scalar);
     }
 
-    // allocate more buffers than needed to reduce the need
+    // allocate more buffer space than needed to reduce the need
     // for resizing.
     arena.resize(totalBufferSize_ * 2);
     measurements = arena.allocate<MeasurementType>(edgeSize);
@@ -464,7 +464,9 @@ void EdgeSet<DIM, E, F, VertexTypes...>::init(
         {
             omega->push_back(ScalarCast(edge->getInformation()));
         }
-        measurements->push_back(*(static_cast<MeasurementType*>(edge->getMeasurement())));
+
+        MeasurementType measurement = *(static_cast<MeasurementType*>(edge->getMeasurement()));
+        measurements->push_back(measurement);
 
         if (VertexSize == 1)
         {
@@ -522,4 +524,5 @@ template <int DIM, typename E, typename F, typename... VertexTypes>
 void EdgeSet<DIM, E, F, VertexTypes...>::clearDevice() noexcept
 {
     arena.clear();
+    edgeOutliers.clear();
 }


### PR DESCRIPTION
Its important to ensure that memory addresses are correctly aligned as CUDA is sensitive to incorrect alignment (expects 64bit mem address alignment). The arena class was only aligning to the first type - as generic types were allowed then these were incorrectly aligned. So added an align pointer function which aligns the each mem pointer and the offset is adjusted to take into account any alignment that occurs.