### PR TITLE
Optimisations for BA

### DIFF
--- a/src/cuda/cuda_constants.h
+++ b/src/cuda/cuda_constants.h
@@ -23,6 +23,14 @@ constexpr int BLOCK_ACTIVE_ERRORS = 512;
 constexpr int BLOCK_MAX_DIAGONAL = 512;
 constexpr int BLOCK_COMPUTE_SCALE = 512;
 constexpr int BLOCK_QUADRATIC_FORM = 512;
+constexpr int ADD_LAMBDA_BLOCK_SIZE = 512;
+constexpr int RESTORE_DIAGONAL_BLOCK_SIZE = 1024;
+constexpr int COMPUTE_BSCHURE_BLOCK_SIZE = 512;
+constexpr int COMPUTE_HSCHURE_BLOCK_SIZE = 256;
+constexpr int TWIST_CSR_BLOCK_SIZE = 512;
+constexpr int SCHUR_COMP_POST_BLOCK_SIZE = 1024;
+constexpr int UPDATE_POSES_BLOCK_SIZE = 512;
+constexpr int UPDATE_LANDMARKS_BLOCK_SIZE = 512;
 
 } // namespace gpu
 } // namespace cugo


### PR DESCRIPTION
More of a fix - the divup function which calculates the gird based on data size and block size doesn't work well and usually equates to one or two grids which is basically running this in a non-concurrent environment most of the time which is the reason that the GPU is running than the CPU version.