### PR TITLE
Add event handling and streams to all BA kernel calls

### DIFF
--- a/samples/sample_ba_from_file/main.cpp
+++ b/samples/sample_ba_from_file/main.cpp
@@ -162,6 +162,7 @@ static cugo::CudaGraphOptimisation::Ptr readGraph(const std::string& filename)
     // read camera parameters
     optimizer->addEdgeSet<cugo::MonoEdgeSet>(monoEdgeSet);
     optimizer->addEdgeSet<cugo::StereoEdgeSet>(stereoEdgeSet);
+    stereoEdgeSet->setRobustKernel(cugo::RobustKernelType::None, 1.0);
 
     // "warm-up" to avoid overhead
     optimizer->initialize();

--- a/src/block_solver.h
+++ b/src/block_solver.h
@@ -239,8 +239,10 @@ private:
 
     /// temporary buffers
     DeviceBuffer<Scalar> d_chi_;
-    HostAsyncVec<Scalar, 40> h_tmpMax_;
-    DeviceBuffer<Scalar> d_tmpMax_;
+    HostAsyncVec<Scalar, 40> h_tmpMax_hpp_;
+    HostAsyncVec<Scalar, 40> h_tmpMax_hll_;
+    DeviceBuffer<Scalar> d_tmpMax_hpp_;
+    DeviceBuffer<Scalar> d_tmpMax_hll_;
     
     GpuVec1i d_nnzPerCol_;
 

--- a/src/cholesky.h
+++ b/src/cholesky.h
@@ -59,7 +59,7 @@ public:
 
     void setPermutaion(int size, const int* P, cudaStream_t stream = 0);
 
-    void analyze(int nnz, const int* csrRowPtr, const int* csrColInd, cudaStream_t stream = 0);
+    void analyze(int nnz, const int* csrRowPtr, const int* csrColInd, const CudaDeviceInfo& deviceInfo);
 
     void factorize(const T* d_A);
 

--- a/src/cholesky.hpp
+++ b/src/cholesky.hpp
@@ -210,7 +210,7 @@ void CuSparseCholeskySolver<T>::setPermutaion(int size, const int* P, cudaStream
 
 template <typename T>
 void CuSparseCholeskySolver<T>::analyze(
-    int nnz, const int* csrRowPtr, const int* csrColInd, cudaStream_t stream)
+    int nnz, const int* csrRowPtr, const int* csrColInd, const CudaDeviceInfo& deviceInfo)
 {
     const int size = Acsr.size();
     Acsr.resizeNonZeros(nnz);
@@ -231,11 +231,12 @@ void CuSparseCholeskySolver<T>::analyze(
             Acsr.rowPtr(),
             Acsr.colInd(),
             d_map,
-            d_nnzPerRow);
+            d_nnzPerRow,
+            deviceInfo);
     }
     else
     {
-        Acsr.uploadAsync(nullptr, csrRowPtr, csrColInd, stream);
+        Acsr.uploadAsync(nullptr, csrRowPtr, csrColInd, deviceInfo.stream);
     }
 
     cholesky.analyze(Acsr);

--- a/src/cuda/cuda_block_solver.h
+++ b/src/cuda/cuda_block_solver.h
@@ -21,11 +21,12 @@ limitations under the License.
 #include "fixed_vector.h"
 #include "graph_optimisation_options.h"
 #include "measurements.h"
-#include "robust_kernel.h"
 #include "cuda_device.h"
+#include "robust_kernel.h"
 
 namespace cugo
 {
+
 namespace gpu
 {
 
@@ -57,18 +58,23 @@ void recordEvent(const CudaDeviceInfo& info);
 
 void waitForEvent(const cudaEvent_t event);
 
+void createRkFunction(RobustKernelType type, const GpuVec<Scalar>& d_delta);
+
+void deleteRkFunction();
+
 void buildHplStructure(
     GpuVec3i& blockpos,
     GpuHplBlockMat& Hpl,
     GpuVec1i& indexPL,
     GpuVec1i& nnzPerCol,
-    cudaStream_t stream = 0);
+    const CudaDeviceInfo& deviceInfo1,
+    const CudaDeviceInfo& deviceInfo2);
 
 void findHschureMulBlockIndices(
     const GpuHplBlockMat& Hpl,
     const GpuHscBlockMat& Hsc,
     GpuVec3i& mulBlockIds,
-    cudaStream_t stream = 0);
+    const CudaDeviceInfo& deviceInfo);
 
 Scalar maxDiagonal(
     const GpuPxPBlockVec& Hpp, Scalar* d_maxD, Scalar* h_tmpMax, const CudaDeviceInfo& deviceInfo);
@@ -93,7 +99,7 @@ void computeBschure(
     GpuPx1BlockVec& bsc,
     GpuLxLBlockVec& invHll,
     GpuPxLBlockVec& Hpl_invHll,
-    const cudaStream_t& stream = 0);
+    const CudaDeviceInfo& deviceInfo);
 
 void computeHschure(
     const GpuPxPBlockVec& Hpp,
@@ -101,13 +107,13 @@ void computeHschure(
     const GpuHplBlockMat& Hpl,
     const GpuVec3i& mulBlockIds,
     GpuHscBlockMat& Hsc,
-    const cudaStream_t& stream = 0);
+    const CudaDeviceInfo& deviceInfo);
 
 void convertHschureBSRToCSR(
     const GpuHscBlockMat& HscBSR,
     const GpuVec1i& BSR2CSR,
     GpuVec1d& HscCSR,
-    const cudaStream_t& stream = 0);
+    const CudaDeviceInfo& deviceInfo);
 
 void convertHppBSRToCSR(const GpuHppBlockMat& HppBSR, const GpuVec1i& BSR2CSR, GpuVec1d& HppCSR);
 
@@ -120,7 +126,8 @@ void twistCSR(
     int* dstRowPtr,
     int* dstColInd,
     int* dstMap,
-    int* nnzPerRow);
+    int* nnzPerRow,
+    const CudaDeviceInfo& deviceInfo);
 
 void permute(int size, const Scalar* src, Scalar* dst, const int* P);
 
@@ -129,7 +136,8 @@ void schurComplementPost(
     const GpuLx1BlockVec& bl,
     const GpuHplBlockMat& Hpl,
     const GpuPx1BlockVec& xp,
-    GpuLx1BlockVec& xl);
+    GpuLx1BlockVec& xl,
+    const CudaDeviceInfo& deviceInfo);
 
 void updatePoses(const GpuPx1BlockVec& xp, GpuVecSe3d& estimate, const CudaDeviceInfo& deviceInfo);
 

--- a/src/cuda_linear_solver.cpp
+++ b/src/cuda_linear_solver.cpp
@@ -23,7 +23,8 @@ limitations under the License.
 
 namespace cugo
 {
-void HscSparseLinearSolver::initialize(HschurSparseBlockMatrix& Hsc, cudaStream_t stream)
+void HscSparseLinearSolver::initialize(
+    HschurSparseBlockMatrix& Hsc, const CudaDeviceInfo& deviceInfo)
 {
     const int size = Hsc.rows();
     const int nnz = Hsc.nnzSymm();
@@ -33,10 +34,10 @@ void HscSparseLinearSolver::initialize(HschurSparseBlockMatrix& Hsc, cudaStream_
     // set permutation
     P_.resize(size);
     cholesky_.reordering(size, nnz, Hsc.rowPtr(), Hsc.colInd(), P_.data());
-    cholesky_.setPermutaion(size, P_.data(), stream);
+    cholesky_.setPermutaion(size, P_.data(), deviceInfo.stream);
 
     // analyze
-    cholesky_.analyze(nnz, Hsc.rowPtr(), Hsc.colInd(), stream);
+    cholesky_.analyze(nnz, Hsc.rowPtr(), Hsc.colInd(), deviceInfo);
 }
 
 bool HscSparseLinearSolver::solve(const Scalar* d_A, const Scalar* d_b, Scalar* d_x)
@@ -54,7 +55,7 @@ bool HscSparseLinearSolver::solve(const Scalar* d_A, const Scalar* d_b, Scalar* 
     return true;
 }
 
-void HppSparseLinearSolver::initialize(HppSparseBlockMatrix& Hpp)
+void HppSparseLinearSolver::initialize(HppSparseBlockMatrix& Hpp, const CudaDeviceInfo& deviceInfo)
 {
     const int size = Hpp.rows();
     const int nnz = Hpp.nnzSymm();
@@ -62,7 +63,7 @@ void HppSparseLinearSolver::initialize(HppSparseBlockMatrix& Hpp)
     cholesky_.resize(size);
 
     // analyze
-    cholesky_.analyze(nnz, Hpp.rowPtr(), Hpp.colInd());
+    cholesky_.analyze(nnz, Hpp.rowPtr(), Hpp.colInd(), deviceInfo);
 }
 
 bool HppSparseLinearSolver::solve(const Scalar* d_A, const Scalar* d_b, Scalar* d_x)

--- a/src/cuda_linear_solver.h
+++ b/src/cuda_linear_solver.h
@@ -43,7 +43,7 @@ public:
     using PermutationMatrix = Eigen::PermutationMatrix<Eigen::Dynamic, Eigen::Dynamic>;
     using Cholesky = CuSparseCholeskySolver<Scalar>;
 
-    void initialize(HschurSparseBlockMatrix& Hsc, cudaStream_t stream);
+    void initialize(HschurSparseBlockMatrix& Hsc, const CudaDeviceInfo& deviceInfo);
 
     bool solve(const Scalar* d_A, const Scalar* d_b, Scalar* d_x) override;
 
@@ -58,7 +58,7 @@ class HppSparseLinearSolver : public LinearSolver
 public:
     using Cholesky = CuSparseCholeskySolver<Scalar>;
 
-    void initialize(HppSparseBlockMatrix& Hpp);
+    void initialize(HppSparseBlockMatrix& Hpp, const CudaDeviceInfo& deviceInfo);
 
     bool solve(const Scalar* d_A, const Scalar* d_b, Scalar* d_x) override;
 

--- a/src/optimisable_graph.h
+++ b/src/optimisable_graph.h
@@ -571,13 +571,6 @@ public:
     virtual void setRobustKernel(const RobustKernelType type, Scalar delta) noexcept = 0;
 
     /**
-     * @brief Get the Robust Kernel associated with this set.
-     * @return A pointer to the RobustKernel class associated with this set. If not set, will be
-     * nullptr.
-     */
-    virtual RobustKernel& robustKernel() noexcept = 0;
-
-    /**
      * @brief Sets the information for this edge set.
      * Note: option @p perEdgeInformation must be false when using this function
      */
@@ -690,7 +683,6 @@ public:
     const EdgeContainer& get() noexcept;
     const int dim() const noexcept override;
     void setRobustKernel(const RobustKernelType type, Scalar delta) noexcept override;
-    RobustKernel& robustKernel() noexcept override;
     void clearEdges() noexcept override;
     void setInformation(const Information info) noexcept override;
     Information getInformation() noexcept override;
@@ -719,7 +711,7 @@ protected:
     EdgeContainer edges;
     /// The number of active edges (has a non-fixed vertex)
     size_t activeEdgeSize_;
-    /// The robust kernal associated with this edge set. Defaults to None.
+    /// The robust kernal parameters associated with this edge set.
     RobustKernel kernel;
     /// The threshold in which an error is considered a outlier
     Scalar outlierThreshold;

--- a/src/optimisable_graph.hpp
+++ b/src/optimisable_graph.hpp
@@ -370,14 +370,7 @@ template <int DIM, typename E, typename... VertexTypes>
 void EdgeSet<DIM, E, VertexTypes...>::setRobustKernel(
     const RobustKernelType type, Scalar delta) noexcept
 {
-    this->kernel.type = type;
-    this->kernel.delta = delta;
-}
-
-template <int DIM, typename E, typename... VertexTypes>
-RobustKernel& EdgeSet<DIM, E, VertexTypes...>::robustKernel() noexcept
-{
-    return kernel;
+    kernel.create(type, delta);
 }
 
 template <int DIM, typename E, typename... VertexTypes>
@@ -559,8 +552,6 @@ void EdgeSet<DIM, E, VertexTypes...>::mapDevice(
     if (outlierThreshold > 0.0)
     {
         d_outliers.resize(activeEdgeSize_);
-        // upload the robust kernel delta value
-        kernel.d_delta.assign(1, &kernel.delta);
     }
     if (edge2HData)
     {

--- a/src/robust_kernel.cpp
+++ b/src/robust_kernel.cpp
@@ -1,0 +1,31 @@
+#include "robust_kernel.h"
+
+#include "cuda/cuda_block_solver.h"
+
+namespace cugo
+{
+
+RobustKernel::RobustKernel() : isInit_(false) {}
+RobustKernel::~RobustKernel()
+{
+    if (isInit_)
+    {
+        gpu::deleteRkFunction();
+    }
+}
+
+void RobustKernel::create(const RobustKernelType type, const Scalar delta)
+{
+    d_delta_.assign(1, &delta);
+
+    if (isInit_)
+    {
+        // delete the old virtual function before creating a new one
+        gpu::deleteRkFunction();
+    }
+    gpu::createRkFunction(type, d_delta_);
+    isInit_ = true;
+}
+
+
+}

--- a/src/robust_kernel.h
+++ b/src/robust_kernel.h
@@ -3,6 +3,8 @@
 #include "scalar.h"
 #include "device_matrix.h"
 
+#include <cassert>
+
 namespace cugo
 {
 
@@ -10,20 +12,25 @@ enum class RobustKernelType
 {
     None,
     Cauchy,
-    Turkey
+    Tukey
 };
 
 /**
  * @brief Robust kernel paramters.
  */
-struct RobustKernel
+class RobustKernel
 {
-    RobustKernel() : type(RobustKernelType::None), delta(1.0) {}
-    RobustKernel(const RobustKernelType t, Scalar d) : type(t), delta(d) {}
+public:
 
-    RobustKernelType type;
-    Scalar delta;
-    GpuVec<Scalar> d_delta;
+    RobustKernel();
+    ~RobustKernel();
+
+    void create(const RobustKernelType type, const Scalar delta);
+
+private:
+
+    GpuVec<Scalar> d_delta_;
+    bool isInit_;
 };
 
 } // namespace cugo


### PR DESCRIPTION
This fixes the sample program which was failing on factorisation due to syncing errors. All BA kernel calls are properly synced using events - also moves all kernel calls into streams.