### PR TITLE
Add stream and event handling to robust kernel function creation

### DIFF
--- a/include/cuda_graph_optimisation.h
+++ b/include/cuda_graph_optimisation.h
@@ -218,6 +218,7 @@ public:
     bool addEdgeSet(T* edgeSet)
     {
         assert(edgeSet != nullptr);
+        edgeSet->getRobustKernel().setDeviceInfo(cudaDevice_.getStreamAndEvent(0));
         edgeSets.push_back(edgeSet);
         return true;
     }

--- a/src/cuda/cuda_block_solver.cu
+++ b/src/cuda/cuda_block_solver.cu
@@ -1530,14 +1530,12 @@ void calculateOccupancy(int size, void* kernelFunc, int& outputBlockSize, int& o
        
 void waitForEvent(const cudaEvent_t event) { CUDA_CHECK(cudaEventSynchronize(event)); }
 
-void createRkFunction(RobustKernelType type, const GpuVec<Scalar>& d_delta)
+void createRkFunction(
+    RobustKernelType type, const GpuVec<Scalar>& d_delta, const CudaDeviceInfo& deviceInfo)
 {
-    createRkFunctionKernel<<<1, 1>>>(type, d_delta.data());
-}
-
-void deleteRkFunction()
-{ 
-    deleteRkFunctionKernel<<<1, 1>>>(); 
+    createRkFunctionKernel<<<1, 1, 0, deviceInfo.stream>>>(type, d_delta.data());
+    CUDA_CHECK(cudaEventRecord(deviceInfo.event, deviceInfo.stream));
+    CUDA_CHECK(cudaEventSynchronize(deviceInfo.event));
 }
 
 void exclusiveScan(const int* src, int* dst, int size)

--- a/src/cuda/cuda_block_solver.h
+++ b/src/cuda/cuda_block_solver.h
@@ -58,9 +58,8 @@ void recordEvent(const CudaDeviceInfo& info);
 
 void waitForEvent(const cudaEvent_t event);
 
-void createRkFunction(RobustKernelType type, const GpuVec<Scalar>& d_delta);
-
-void deleteRkFunction();
+void createRkFunction(
+    RobustKernelType type, const GpuVec<Scalar>& d_delta, const CudaDeviceInfo& deviceInfo);
 
 void buildHplStructure(
     GpuVec3i& blockpos,

--- a/src/cuda_device.h
+++ b/src/cuda_device.h
@@ -27,7 +27,7 @@ public:
     static constexpr int MaxEventCount = 8;
 
     using StreamContainer = std::array<cudaStream_t, MaxStreamCount>;
-    using EventContainer = std::array<cudaEvent_t, MaxStreamCount>;
+    using EventContainer = std::array<cudaEvent_t, MaxEventCount>;
 
     CudaDevice() { init(); }
     ~CudaDevice();

--- a/src/optimisable_graph.h
+++ b/src/optimisable_graph.h
@@ -570,6 +570,8 @@ public:
      */
     virtual void setRobustKernel(const RobustKernelType type, Scalar delta) noexcept = 0;
 
+    virtual RobustKernel& getRobustKernel() noexcept = 0;
+
     /**
      * @brief Sets the information for this edge set.
      * Note: option @p perEdgeInformation must be false when using this function
@@ -683,6 +685,7 @@ public:
     const EdgeContainer& get() noexcept;
     const int dim() const noexcept override;
     void setRobustKernel(const RobustKernelType type, Scalar delta) noexcept override;
+    RobustKernel& getRobustKernel() noexcept;
     void clearEdges() noexcept override;
     void setInformation(const Information info) noexcept override;
     Information getInformation() noexcept override;

--- a/src/optimisable_graph.hpp
+++ b/src/optimisable_graph.hpp
@@ -374,6 +374,12 @@ void EdgeSet<DIM, E, VertexTypes...>::setRobustKernel(
 }
 
 template <int DIM, typename E, typename... VertexTypes>
+RobustKernel& EdgeSet<DIM, E, VertexTypes...>::getRobustKernel() noexcept
+{
+    return kernel;
+}
+
+template <int DIM, typename E, typename... VertexTypes>
 void EdgeSet<DIM, E, VertexTypes...>::setOutlierThreshold(const Scalar errorThreshold) noexcept
 {
     this->outlierThreshold = errorThreshold;

--- a/src/robust_kernel.cpp
+++ b/src/robust_kernel.cpp
@@ -5,27 +5,19 @@
 namespace cugo
 {
 
-RobustKernel::RobustKernel() : isInit_(false) {}
+RobustKernel::RobustKernel()  {}
 RobustKernel::~RobustKernel()
 {
-    if (isInit_)
-    {
-        gpu::deleteRkFunction();
-    }
 }
 
-void RobustKernel::create(const RobustKernelType type, const Scalar delta)
+void RobustKernel::create(
+    const RobustKernelType type, const Scalar delta)
 {
     d_delta_.assign(1, &delta);
-
-    if (isInit_)
-    {
-        // delete the old virtual function before creating a new one
-        gpu::deleteRkFunction();
-    }
-    gpu::createRkFunction(type, d_delta_);
-    isInit_ = true;
+    gpu::createRkFunction(type, d_delta_, deviceInfo_);
 }
+
+void RobustKernel::setDeviceInfo(const CudaDeviceInfo& deviceInfo) { deviceInfo_ = deviceInfo; }
 
 
 }

--- a/src/robust_kernel.h
+++ b/src/robust_kernel.h
@@ -2,6 +2,7 @@
 
 #include "scalar.h"
 #include "device_matrix.h"
+#include "cuda_device.h"
 
 #include <cassert>
 
@@ -21,16 +22,16 @@ enum class RobustKernelType
 class RobustKernel
 {
 public:
-
     RobustKernel();
     ~RobustKernel();
 
     void create(const RobustKernelType type, const Scalar delta);
+    void setDeviceInfo(const CudaDeviceInfo& deviceInfo);
 
 private:
+    CudaDeviceInfo deviceInfo_;
 
     GpuVec<Scalar> d_delta_;
-    bool isInit_;
 };
 
 } // namespace cugo


### PR DESCRIPTION
There was an issue with BA when ruuning with KdVisual that it would throw a CUDA error when getting the iteration where the robust kernel is deleted and a new one created which switches off the kernel. Turns out the issue was that I forgot that i was using a C-style array for aligned memory when creating the robust kernel function so trying to deleete this was causing the error. So I have removed the delete function and also added stream/event handling to the kernal creation function so that it ensures the function kernel has ran before trying to use the virtual kernel function in other kernels.