### PR TITLE
Update compute error kernels

### DIFF
--- a/include/ba_types.h
+++ b/include/ba_types.h
@@ -55,11 +55,11 @@ public:
             d_omegas,
             d_edge2PL,
             d_cameras,
-            outlierThreshold,
             kernel,
-            d_errors,
             d_outliers,
+            d_errors,
             d_Xcs,
+            d_chiValues,
             chi,
             deviceInfo);
     }
@@ -123,11 +123,11 @@ public:
             d_omegas,
             d_edge2PL,
             d_cameras,
-            outlierThreshold,
             kernel,
-            d_errors,
             d_outliers,
+            d_errors,
             d_Xcs,
+            d_chiValues,
             chi,
             deviceInfo);
     }

--- a/src/block_solver.cpp
+++ b/src/block_solver.cpp
@@ -413,7 +413,7 @@ void BlockSolver::updateEdges(const EdgeSetVec& edgeSets)
 { 
     for (const auto& edgeSet : edgeSets)
     {
-        edgeSet->updateEdges();
+        edgeSet->updateEdges(cudaDevice_.getStreamAndEvent(1));
     }
 }
 

--- a/src/cuda/cuda_block_solver.h
+++ b/src/cuda/cuda_block_solver.h
@@ -149,6 +149,13 @@ void computeScale(
     Scalar lambda,
     const CudaDeviceInfo& deviceInfo);
 
+void computeOutliers(
+    int nedges,
+    const Scalar errorTheshold,
+    const Scalar* chiValues,
+    int* outliers,
+    const CudaDeviceInfo& deviceInfo);
+
 template <int M>
 void CUGO_API constructQuadraticForm_(
     const GpuVec3d& Xcs,
@@ -167,19 +174,20 @@ void CUGO_API constructQuadraticForm_(
     GpuHplBlockMat& Hpl,
     const CudaDeviceInfo& deviceInfo);
 
+
 template <int M>
-Scalar CUGO_API computeActiveErrors_(
+Scalar computeActiveErrors_(
     const GpuVecSe3d& poseEstimate,
     const GpuVec3d& landmarkEstimate,
     const GpuVecxd<M>& measurements,
     const GpuVec1d& omegas,
     const GpuVec2i& edge2PL,
     const GpuVec5d& cameras,
-    const Scalar errorThreshold,
     const RobustKernel& robustKernel,
+    const GpuVec1i& outliers,
     GpuVecxd<M>& errors,
-    GpuVec1i& outliers,
     GpuVec3d& Xcs,
+    Scalar* chiValues,
     Scalar* chi,
     const CudaDeviceInfo& deviceInfo);
 

--- a/src/optimisable_graph.h
+++ b/src/optimisable_graph.h
@@ -562,7 +562,7 @@ public:
     * @brief If the outlier threshold is greater than zero, then any edge outliers determined by the 
     * @p computeErrors kernel, will be removed from the edge container.
     */
-    virtual void updateEdges() noexcept = 0;
+    virtual void updateEdges(const CudaDeviceInfo& deviceInfo) noexcept = 0;
 
     /**
      * @brief Set the Robust Kernel associated with this set (applied to all edges)
@@ -681,7 +681,7 @@ public:
     void removeEdge(BaseEdge* edge) override;
     size_t nedges() const noexcept override;
     size_t nActiveEdges() const noexcept override;
-    void updateEdges() noexcept override;
+    void updateEdges(const CudaDeviceInfo& deviceInfo) noexcept override;
     const EdgeContainer& get() noexcept;
     const int dim() const noexcept override;
     void setRobustKernel(const RobustKernelType type, Scalar delta) noexcept override;
@@ -768,6 +768,7 @@ protected:
     GpuVec1i d_edge2Hpl;
     DeviceBuffer<Scalar> d_outlierThreshold;
     GpuVec1i d_outliers;
+    GpuVec<Scalar> d_chiValues;
 };
 
 


### PR DESCRIPTION
For use with the edge activation logic, the indiviudal chi values will be needed for passing to the computeOutliers kernel. At present, only the total chi2 value so output so this PR breaks down the error kernel into two stages - the first which computes the indivudal chi values (and error, xcs) and the second which computes the total.